### PR TITLE
Change events

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Most of the dependencies are internal, meaning [Leiningen](https://github.com/te
 
 * [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) - a Java 8+ JRE is needed to run Clojure
 * [Leiningen](https://github.com/technomancy/leiningen) 2.5.1+ - Clojure's build and dependency management tool
-* [RethinkDB](http://rethinkdb.com/) v2.3.5+ - a multi-modal (document, key/value, relational) open source NoSQL database
+* [RethinkDB](http://rethinkdb.com/) v2.3.6+ - a multi-modal (document, key/value, relational) open source NoSQL database
 
 #### Java
 

--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ The storage service is composed of 7 main responsibilities:
 
 - CRUD of orgs, boards, stories and entries
 - Access control to orgs, boards, stories and entries
-- Notifying the Slack bot of new orgs via SQS
-- Notifying the Slack bot and Email service of share requests via SQS
-- Notifying the Slack bot and Email service of new invites via SQS
-- Notifying the Email service of password reset and email validation requests via SQS
-- Notifying the Change service of entry publish events via SQS
+- Notifying the [Bot service](https://github.com/open-company/open-company-bot) of new orgs via SQS
+- Notifying the [Bot service](https://github.com/open-company/open-company-bot) and [Email service](https://github.com/open-company/open-company-email) of share requests via SQS
+- Notifying the [Bot service](https://github.com/open-company/open-company-bot) and [Email service](https://github.com/open-company/open-company-email) of new invites via SQS
+- Notifying the [Email service](https://github.com/open-company/open-company-email) of password reset and email validation requests via SQS
+- Notifying the [Change service](https://github.com/open-company/open-company-change) of board and entry changes via SQS
 
 The storage service provides a HATEOAS REST API:
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![MPL License](http://img.shields.io/badge/license-MPL-blue.svg?style=flat)](https://www.mozilla.org/MPL/2.0/)
 [![Build Status](http://img.shields.io/travis/open-company/open-company-storage.svg?style=flat)](https://travis-ci.org/open-company/open-company-storage)
-[![Dependency Status](https://www.versioneye.com/user/projects/5955236b6725bd0054e4c8a1/badge.svg?style=flat)](https://www.versioneye.com/user/projects/5955236b6725bd0054e4c8a1)
-[![Roadmap on Trello](http://img.shields.io/badge/roadmap-trello-blue.svg?style=flat)](https://trello.com/b/3naVWHgZ/open-company-development)
 
 
 ## Background

--- a/REPL_notes.clj
+++ b/REPL_notes.clj
@@ -74,19 +74,23 @@
 ;; Remove a property from all entries
 (with-open [c (apply r/connect conn2)]
   (-> (r/table "entries")
-    (r/replace (r/fn [section]
-      (r/without section [:data :intervals :metrics :units :prompt])))
+    (r/replace (r/fn [e]
+      (r/without e [:data :intervals :metrics :units :prompt])))
+    (r/run c)))
+
+;; Update a property in an entry
+(with-open [c (apply r/connect conn2)]
+  (-> (r/table "entries")
+    (r/get "b0d3-4072-954e")
+    (r/update (r/fn [e]
+      {:published-at "2017-10-27T19:12:40.644Z"}))
     (r/run c)))
 
 ;; Provide a new slug for an org
+;; Insert a copy with the new slug
 (with-open [c (apply r/connect conn2)]
   (-> (r/table "orgs")
-      (r/insert (assoc (company/get-company conn "old-slug") :slug "new-slug"))
-      (r/run c)))
-(with-open [c (apply r/connect conn2)]
-  (-> (r/table "entries")
-      (r/get-all ["old-slug"] {:index "company-slug"})
-      (r/update {:slug "new-slug"})
+      (r/insert (assoc (org/get-org conn "old-slug") :slug "new-slug"))
       (r/run c)))
 (org/delete-org! conn "old-slug")
 

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
     ;; Utility functions https://github.com/weavejester/medley
     [medley "1.0.0"]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
-    [zprint "0.4.3"]
+    [zprint "0.4.4"]
     
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     [open-company/lib "0.14.7"]
@@ -124,7 +124,7 @@
         ;; Dead code finder https://github.com/venantius/yagni
         [venantius/yagni "0.1.4" :exclusions [org.clojure/clojure]]
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
-        [lein-zprint "0.3.3" :exclusions [org.clojure/clojure]]
+        [lein-zprint "0.3.4" :exclusions [org.clojure/clojure]]
       ]  
     }]
     :repl-config [:dev {

--- a/project.clj
+++ b/project.clj
@@ -14,16 +14,16 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0-beta3"]
+    [org.clojure/clojure "1.9.0-beta4"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.5"]
     ;; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-devel "1.6.2"]
+    [ring/ring-devel "1.6.3"]
     ;; Web application library https://github.com/ring-clojure/ring
     ;; NB: clj-time pulled in by oc.lib
     ;; NB: joda-time pulled in by oc.lib via clj-time
     ;; NB: commons-codec pulled in by oc.lib
-    [ring/ring-core "1.6.2" :exclusions [clj-time joda-time commons-codec]]
+    [ring/ring-core "1.6.3" :exclusions [clj-time joda-time commons-codec]]
     ;; CORS library https://github.com/jumblerg/ring.middleware.cors
     [jumblerg/ring.middleware.cors "1.0.1"]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0-beta2"]
+    [org.clojure/clojure "1.9.0-beta3"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.5"]
     ;; Web application library https://github.com/ring-clojure/ring

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -131,7 +131,7 @@
     
     (do
       (timbre/info "Created board:" (:uuid board-result) "for org:" org-slug)
-      (change/send-trigger! (change/->trigger :add board-result))
+      (change/send-trigger! (change/->trigger :add :board board-result))
       {:created-board board-result})
     
     (do (timbre/error "Failed creating board for org:" org-slug) false)))
@@ -176,7 +176,7 @@
             updated-result (board-res/update-board! conn (:uuid updated-board) updated-board)]
     (do
       (timbre/info "Updated board:" slug "of org:" org-slug)
-      (change/send-trigger! (change/->trigger :refresh board))
+      (change/send-trigger! (change/->trigger :refresh :board updated-result))
       (if (and (= "private" (:access updated-board)) ; board is being set private
                (nil? ((set (:authors updated-result)) user-id))) ; and current user is not an author
         (add-member conn ctx org-slug slug :authors user-id) ; make the current user an author
@@ -190,7 +190,7 @@
             _delete-result (board-res/delete-board! conn (:uuid board))]
     (do 
       (timbre/info "Deleted board:" slug "of org:" org-slug)
-      (change/send-trigger! (change/->trigger :delete board))
+      (change/send-trigger! (change/->trigger :delete :board board))
       true)
     (do (timbre/warn "Failed deleting board:" slug "of org:" org-slug) false)))
 

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -11,6 +11,7 @@
             [oc.lib.api.common :as api-common]
             [oc.storage.config :as config]
             [oc.storage.api.access :as access]
+            [oc.storage.async.change :as change]
             [oc.storage.representations.media-types :as mt]
             [oc.storage.representations.board :as board-rep]
             [oc.storage.representations.entry :as entry-rep]
@@ -130,6 +131,7 @@
     
     (do
       (timbre/info "Created board:" (:uuid board-result) "for org:" org-slug)
+      (change/send-trigger! (change/->trigger :add board-result))
       {:created-board board-result})
     
     (do (timbre/error "Failed creating board for org:" org-slug) false)))
@@ -174,6 +176,7 @@
             updated-result (board-res/update-board! conn (:uuid updated-board) updated-board)]
     (do
       (timbre/info "Updated board:" slug "of org:" org-slug)
+      (change/send-trigger! (change/->trigger :refresh board))
       (if (and (= "private" (:access updated-board)) ; board is being set private
                (nil? ((set (:authors updated-result)) user-id))) ; and current user is not an author
         (add-member conn ctx org-slug slug :authors user-id) ; make the current user an author
@@ -185,7 +188,10 @@
   (timbre/info "Deleting board:" slug "of org:" org-slug)
   (if-let* [board (:existing-board ctx)
             _delete-result (board-res/delete-board! conn (:uuid board))]
-    (do (timbre/info "Deleted board:" slug "of org:" org-slug) true)
+    (do 
+      (timbre/info "Deleted board:" slug "of org:" org-slug)
+      (change/send-trigger! (change/->trigger :delete board))
+      true)
     (do (timbre/warn "Failed deleting board:" slug "of org:" org-slug) false)))
 
 ;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg

--- a/src/oc/storage/async/change.clj
+++ b/src/oc/storage/async/change.clj
@@ -7,15 +7,22 @@
             [oc.storage.config :as config]))
 
 (def ChangeTrigger
-  {:type (schema/enum "change")
+  "
+  A trigger for one of the various types of changes that are published:
+
+  add - the specified content-id is newly created, this happens when a board or entry is added
+  refresh - the content-id should be refreshed, this happens when a board or entry is updated
+  delete - the specified content-id is deleted, this happens when a board or entry is removed
+  "
+  {:type (schema/enum :add :refresh :delete)
    :container-id lib-schema/UniqueID
    :content-id lib-schema/UniqueID
    :change-at lib-schema/ISO8601})
 
-(defn ->trigger [content]
-  {:type "change"
+(defn ->trigger [change-type content]
+  {:type change-type
    :content-id (:uuid content)
-   :container-id (:board-uuid content)
+   :container-id (or (:board-uuid content) (:org-uuid content))
    :change-at (or (:published-at content) (:created-at content))})
 
 (defn send-trigger! [trigger]

--- a/src/oc/storage/async/change.clj
+++ b/src/oc/storage/async/change.clj
@@ -16,17 +16,20 @@
   "
   {:type (schema/enum :add :refresh :delete)
    :container-id lib-schema/UniqueID
+   :content-type (schema/enum :board :entry)
    :content-id lib-schema/UniqueID
    :change-at lib-schema/ISO8601})
 
-(defn ->trigger [change-type content]
+(defn ->trigger [change-type content-type content]
   {:type change-type
    :content-id (:uuid content)
+   :content-type content-type
    :container-id (or (:board-uuid content) (:org-uuid content))
    :change-at (or (:published-at content) (:created-at content))})
 
 (defn send-trigger! [trigger]
-  (timbre/info "Change notification request to queue:" config/aws-sqs-change-queue)
+  (timbre/info "Change notification request of" (:type trigger)
+               "for" (:content-id trigger) "to queue" config/aws-sqs-change-queue)
   (timbre/trace "Change request:" trigger)
   (schema/validate ChangeTrigger trigger)
   (timbre/info "Sending request to queue:" config/aws-sqs-change-queue)

--- a/src/oc/storage/representations/org.clj
+++ b/src/oc/storage/representations/org.clj
@@ -6,7 +6,7 @@
             [oc.storage.config :as config]
             [oc.storage.representations.media-types :as mt]))
 
-(def public-representation-props [:slug :name :team-id :logo-url :logo-width :logo-height
+(def public-representation-props [:uuid :slug :name :team-id :logo-url :logo-width :logo-height
                            :boards :created-at :updated-at])
 (def representation-props (concat public-representation-props [:author :authors]))
 


### PR DESCRIPTION
https://trello.com/c/Um6p3FXO

This PR supports [https://github.com/open-company/open-company-web/pull/270](https://github.com/open-company/open-company-web/pull/270).

This updates the SQS triggers sent to change service to have 3 event types: `add`, `refresh`, and `delete` and 2 content types: `board` and `entry` to account for the 6 changes we need to report to the UI:

- board add
- board update
- board delete
- entry add
- entry update
- entry delete

This also puts those triggers in the right place in the API so the SQS events go out for all 6 of the above.

- [x] Review the code
- [x] Follow testing steps in [https://github.com/open-company/open-company-web/pull/270](https://github.com/open-company/open-company-web/pull/270)
- [x] Merge
- [x] Follow the rainbow
