### PR TITLE
Carrot-powered What's New Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,29 +165,53 @@ If you run Linux on your development environment (good for you, hardcore!) you c
 
 RethinkDB [isn't supported on Windows](https://github.com/rethinkdb/rethinkdb/issues/1100) directly. If you are stuck on Windows, you can run Linux in a virtualized environment to host RethinkDB.
 
-#### Required Secrets
+#### Configuration
 
-A secret is shared between the [OpenCompany Authentication Service](https://github.com/open-company/open-company-auth) and the Storage Service for creating and validating [JSON Web Tokens](https://jwt.io/).
-
-An [AWS SQS queue](https://aws.amazon.com/sqs/) is used to pass messages from the Storage Service to other OpenCompany services. Setup an SQS Queue and key/secret access to the queue using the AWS Web Console or API.
-
-Make sure you update the section in `project.clj` that looks like this to contain your actual JWT and AWS SQS secrets:
+Make sure you update the section in `project.clj` that looks like this to contain your specific configuration:
 
 ```clojure
 :dev [:qa {
   :env ^:replace {
+    :db-name "open_company_storage_dev"
+    :liberator-trace "true" ; liberator debug data in HTTP response headers
+    :hot-reload "true" ; reload code when changed on the file system
     :open-company-auth-passphrase "this_is_a_dev_secret" ; JWT secret
     :aws-access-key-id "CHANGE-ME"
     :aws-secret-access-key "CHANGE-ME"
     :aws-sqs-bot-queue "https://sqs.REGION.amazonaws.com/CHANGE/ME" 
     :aws-sqs-email-queue "https://sqs.REGION.amazonaws.com/CHANGE/ME" 
     :aws-sqs-change-queue "https://sqs.REGION.amazonaws.com/CHANGE/ME" 
+    :whats-new-org-slug "carrot"
+    :whats-new-board-slug "whats-new"
   }
 ```
 
 You can also override these settings with environmental variables in the form of `OPEN_COMPANY_AUTH_PASSPHRASE` and
 `AWS_ACCESS_KEY_ID`, etc. Use environmental variables to provide production secrets when running in production.
 
+##### Shared Secrets
+
+A secret, `open-company-auth-passphrase`, is shared between the [OpenCompany Authentication Service](https://github.com/open-company/open-company-auth) and the Storage Service for creating and validating [JSON Web Tokens](https://jwt.io/).
+
+##### HTTP Behavior
+
+There are two options controlling HTTP behavior:
+
+`liberator-trace` will include detailed debug info in HTTP response headers that correspond to each step in the [Liberator decision graph](https://clojure-liberator.github.io/liberator/tutorial/decision-graph.html) for that request.
+
+The `hot-reload` configuration controls if each request checks for updated code to load, useful for development, but not for production.
+
+Both of these settings take the string `true` or `false`.
+
+##### AWS
+
+[AWS SQS](https://aws.amazon.com/sqs/)  queues ace used to pass messages from the Storage Service to other OpenCompany services. Setup an SQS Queue and key/secret access to the queue using the AWS Web Console or API and update the corresponding .
+
+##### What's New
+
+The What's New feature of the [Web UI](https://github.com/open-company/open-company-web) is powered by entries from a public board specified by `whats-new-board`. These entries can be created on the specified board using the Storage service APIs or with the Web UI.
+
+If `whats-new-board` is removed or left blank, no What's New feature will be provided.
 
 ## Technical Design
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Both of these settings take the string `true` or `false`.
 
 ##### AWS
 
-[AWS SQS](https://aws.amazon.com/sqs/)  queues ace used to pass messages from the Storage Service to other OpenCompany services. Setup an SQS Queue and key/secret access to the queue using the AWS Web Console or API and update the corresponding .
+[AWS SQS](https://aws.amazon.com/sqs/)  queues are used to pass messages from the Storage Service to other OpenCompany services. Setup an SQS Queue and key/secret access to the queue using the AWS Web Console or API and update the corresponding `aws-` configuration properties with the key, secret and queue names.
 
 ##### What's New
 

--- a/project.clj
+++ b/project.clj
@@ -103,6 +103,7 @@
         :liberator-trace "true" ; liberator debug data in HTTP response headers
         :hot-reload "true" ; reload code when changed on the file system
         :open-company-auth-passphrase "this_is_a_dev_secret" ; JWT secret
+        :whats-new-board "/orgs/carrot/boards/what-s-new"
         :aws-access-key-id "CHANGE-ME"
         :aws-secret-access-key "CHANGE-ME"
         :aws-sqs-bot-queue "CHANGE-ME"

--- a/src/oc/storage/app.clj
+++ b/src/oc/storage/app.clj
@@ -61,7 +61,8 @@
     "AWS SQS change queue: " c/aws-sqs-change-queue "\n"
     "Hot-reload: " c/hot-reload "\n"
     "Trace: " c/liberator-trace "\n"
-    "Sentry: " c/dsn "\n\n"
+    "Sentry: " c/dsn "\n"
+    "What's New board: " c/whats-new-board "\n\n"
     (when c/intro? "Ready to serve...\n"))))
 
 ;; Ring app definition

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -86,3 +86,5 @@
 (defonce default-reactions ["👌" "👀" "💥"])
 
 (defonce default-activity-limit 20)
+
+(defonce whats-new-board (env :whats-new-board))

--- a/src/oc/storage/representations/org.clj
+++ b/src/oc/storage/representations/org.clj
@@ -50,6 +50,9 @@
         nil))
     org))
 
+(defn- whats-new-link [whats-new-url]
+  (hateoas/link-map "whats-new" hateoas/GET whats-new-url {:accept mt/board-media-type}))
+
 (defn- org-links [org access-level]
   (let [links [(self-link org)]
         activity-links (if (or (= access-level :author) (= access-level :viewer))
@@ -88,10 +91,13 @@
   "Given a sequence of org maps, create a JSON representation of a list of orgs for the REST API."
   [orgs authed?]
   (let [links [(hateoas/self-link "/" {:accept mt/org-collection-media-type}) auth-link]
+        whats-new-links (if config/whats-new-board
+                          (conj links (whats-new-link config/whats-new-board))
+                          links)
         full-links (if authed?
-                      (conj links (hateoas/create-link "/orgs/" {:content-type mt/org-media-type
-                                                                 :accept mt/org-media-type}))
-                      links)]
+                      (conj whats-new-links (hateoas/create-link "/orgs/" {:content-type mt/org-media-type
+                                                                          :accept mt/org-media-type}))
+                      whats-new-links)]
     (json/generate-string
       {:collection {:version hateoas/json-collection-version
                     :href "/"

--- a/src/oc/storage/representations/org.clj
+++ b/src/oc/storage/representations/org.clj
@@ -91,9 +91,9 @@
   "Given a sequence of org maps, create a JSON representation of a list of orgs for the REST API."
   [orgs authed?]
   (let [links [(hateoas/self-link "/" {:accept mt/org-collection-media-type}) auth-link]
-        whats-new-links (if config/whats-new-board
-                          (conj links (whats-new-link config/whats-new-board))
-                          links)
+        whats-new-links (if (clojure.string/blank? config/whats-new-board)
+                          links
+                          (conj links (whats-new-link config/whats-new-board)))
         full-links (if authed?
                       (conj whats-new-links (hateoas/create-link "/orgs/" {:content-type mt/org-media-type
                                                                           :accept mt/org-media-type}))


### PR DESCRIPTION
https://trello.com/c/LWg96uIO

To test this PR:

- [x] Review the code
- [ ] Check out the README configuration improvements, any issue?
- [ ] Set your `whats-new-board` param to `""` (restart), retrieve `/` with the API, no `whats-new` link? Cool beans.
- [ ] Look at the Web UI, does About Carrot just have about stuff with no mention of any what's new (and no 404 trying to retrieve a phantom link)?
- [x] Set your `whats-new-board` param to a public board you have, something like `"/orgs/carrot/boards/what-s-new"` (restart), retrieve `/` with the API, got a `whats-new` link that matches what you configured? Hot beans!
- [x] Look at the Web UI, does About Carrot have the configured board's content?
- [ ] Merge
- [ ] Deploy
- [ ] Kiss the rain down in Africa

