### PR TITLE
Small fix & refactor

### DIFF
--- a/src/oc/storage/async/notification.clj
+++ b/src/oc/storage/async/notification.clj
@@ -29,11 +29,9 @@
 
 ;; ----- Data schema -----
 
-(defn notification-type? [notification-type]
-  (or (= notification-type :add) (= notification-type :update) (= notification-type :delete)))
+(defn- notification-type? [notification-type] (#{:add :update :delete} notification-type))
 
-(defn resource-type? [resource-type]
-  (or (= resource-type :org) (= resource-type :board) (= resource-type :entry)))
+(defn- resource-type? [resource-type] (#{:org :board :entry} resource-type))
 
 (def NotificationTrigger
   "
@@ -48,7 +46,7 @@
 
   The user whose actions triggered the notification is included as `user`.
 
-  A timestamp for when the notice was created is included as `notice-at`.
+  A timestamp for when the notice was created is included as `notification-at`.
   "
   {:notification-type (schema/pred notification-type?)
    :resource-type (schema/pred resource-type?)
@@ -63,7 +61,7 @@
 
 ;; ----- Event handling -----
 
-(defn handle-notification-message
+(defn- handle-notification-message
   [trigger]
   (timbre/debug "Notification request of:" (:notification-type trigger)
                "for:" (trigger :current :uuid) "to topic:" config/aws-sns-storage-topic-arn)
@@ -82,7 +80,7 @@
 
 ;; ----- Event loop -----
 
-(defn notification-loop []
+(defn- notification-loop []
   (reset! notification-go true)
   (timbre/info "Starting notification...")
   (async/go (while @notification-go

--- a/src/oc/storage/representations/entry.clj
+++ b/src/oc/storage/representations/entry.clj
@@ -83,8 +83,9 @@
     (assoc entry :secure-uuid secure-uuid)
     entry))
 
-(defn- include-reactions [entry reactions]
+(defn- include-reactions
   "Include reactions only if we have some."
+  [entry reactions]
   (if (empty? reactions)
     entry
     (assoc entry :reactions reactions)))

--- a/src/oc/storage/representations/entry.clj
+++ b/src/oc/storage/representations/entry.clj
@@ -83,6 +83,12 @@
     (assoc entry :secure-uuid secure-uuid)
     entry))
 
+(defn- include-reactions [entry reactions]
+  "Include reactions only if we have some."
+  (if (empty? reactions)
+    entry
+    (assoc entry :reactions reactions)))
+
 (defun- entry-and-links
   "
   Given an entry and all the metadata about it, render an access level appropriate rendition of the entry
@@ -143,7 +149,7 @@
       (select-keys representation-props)
       (clean-blank-topic)
       (include-secure-uuid secure-uuid access-level)
-      (assoc :reactions reactions)
+      (include-reactions reactions)
       (assoc :links full-links))))
 
   ([entry board-slug org-slug comments reactions access-level user-id secure-access?]


### PR DESCRIPTION
No trello card for this.

In the spirit of small commits!

This is a small fix and a refactor.

The fix is to not include the `reactions` key in entry responses (on their own and embedded in a board).

To test the change, look at board and entry responses (web developer console, or cURL or Paw) as on public content as anonymous (no JWT, or JWT for wrong org) and on content as a team user. You should see no `reactions` key no for the former, rather than a empty `reactions` key. You should still see `reactions` for team members.