### PR TITLE
Rework SNS notification payload

### DIFF
--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -91,21 +91,25 @@
 
 (defn- create-entry [conn ctx entry-for]
   (timbre/info "Creating entry for:" entry-for)
-  (if-let* [new-entry (:new-entry ctx)
+  (if-let* [org (:existing-org ctx)
+            board (:existing-board ctx)
+            new-entry (:new-entry ctx)
             entry-result (entry-res/create-entry! conn new-entry)] ; Add the entry
     
     (do
       (timbre/info "Created entry for:" entry-for "as" (:uuid entry-result))
       (when (= (:status entry-result) "published")
         (change/send-trigger! (change/->trigger :add entry-result)))
-      (notification/send-trigger! (notification/->trigger :add entry-result (:user ctx)))
+      (notification/send-trigger! (notification/->trigger :add org board {:new entry-result} (:user ctx)))
       {:created-entry entry-result})
 
     (do (timbre/error "Failed creating entry:" entry-for) false)))
 
 (defn- update-entry [conn ctx entry-for]
   (timbre/info "Updating entry for:" entry-for)
-  (if-let* [user (:user ctx)
+  (if-let* [org (:existing-org ctx)
+            board (:existing-board ctx)
+            user (:user ctx)
             entry (:existing-entry ctx)
             updated-entry (:updated-entry ctx)
             updated-result (entry-res/update-entry! conn (:uuid updated-entry) updated-entry user)]
@@ -113,7 +117,7 @@
       (timbre/info "Updated entry for:" entry-for)
       (when (= (:status updated-result) "published")
         (change/send-trigger! (change/->trigger :update updated-result)))
-      (notification/send-trigger! (notification/->trigger :update entry updated-result user))
+      (notification/send-trigger! (notification/->trigger :update org board {:old entry :new updated-result} user))
       {:updated-entry updated-result})
 
     (do (timbre/error "Failed updating entry:" entry-for) false)))
@@ -122,25 +126,29 @@
   (timbre/info "Publishing entry for:" entry-for)
   (if-let* [user (:user ctx)
             org (:existing-org ctx)
+            board (:existing-board ctx)
+            entry (:existing-entry ctx)
             updated-entry (:updated-entry ctx)
             publish-result (entry-res/publish-entry! conn (:uuid updated-entry) updated-entry user)]
     (do
       (timbre/info "Published entry for:" (:uuid updated-entry))
-      (change/send-trigger! (change/->trigger :add publish-result))
+      (change/send-trigger! (change/->trigger :add :entry {:content {:new publish-result}}))
       (timbre/info "Published entry:" entry-for)
+      (notification/send-trigger! (notification/->trigger :update org board {:old entry :new publish-result} user))
       {:updated-entry publish-result})
     (do (timbre/error "Failed publishing entry:" entry-for) false)))
 
 (defn- delete-entry [conn ctx entry-for]
   (timbre/info "Deleting entry for:" entry-for)
-  (if-let* [board (:existing-board ctx)
+  (if-let* [org (:existing-org ctx)
+            board (:existing-board ctx)
             entry (:existing-entry ctx)
             _delete-result (entry-res/delete-entry! conn (:uuid entry))]
     (do
       (timbre/info "Deleted entry for:" entry-for)
       (when (= (:status entry) "published")
         (change/send-trigger! (change/->trigger :delete entry)))
-      (notification/send-trigger! (notification/->trigger :delete entry (:user ctx)))
+      (notification/send-trigger! (notification/->trigger :delete org board {:old entry} (:user ctx)))
       true)
     (do (timbre/error "Failed deleting entry for:" entry-for) false)))
 
@@ -272,11 +280,13 @@
   ;; Existentialism
   :exists? (fn [ctx] (if-let* [_slugs? (and (slugify/valid-slug? org-slug)
                                             (slugify/valid-slug? board-slug))
-                               org-uuid (org-res/uuid-for conn org-slug)
+                               org (or (:existing-org ctx)
+                                       (org-res/get-org conn org-slug))
+                               org-uuid (:uuid org)
                                board (board-res/get-board conn org-uuid board-slug)
                                board-uuid (:uuid board)
                                entries (entry-res/list-entries-by-board conn board-uuid)]
-                        {:existing-entries entries :existing-board board}
+                        {:existing-org org :existing-board board :existing-entries entries}
                         false))
 
   ;; Actions

--- a/src/oc/storage/api/orgs.clj
+++ b/src/oc/storage/api/orgs.clj
@@ -86,7 +86,7 @@
           author (:user ctx)]
       (timbre/info "Created org:" uuid)
       (timbre/info "Creating default boards for org:" uuid)
-      (notification/send-trigger! (notification/->trigger :add org-result (:user ctx)))
+      (notification/send-trigger! (notification/->trigger :add {:new org-result} (:user ctx)))
       (doseq [board (:boards config/default-new-org)]
         (create-board conn org-result board author))
       {:created-org org-result})
@@ -99,7 +99,8 @@
             update-result (org-res/update-org! conn slug updated-org)]
     (do
       (timbre/info "Updated org:" slug)
-      (notification/send-trigger! (notification/->trigger :update (:existing-org ctx) update-result (:user ctx)))
+      (notification/send-trigger! (notification/->trigger :update {:old (:existing-org ctx) :new update-result}
+                                                          (:user ctx)))
       {:updated-org update-result})
 
     (do (timbre/error "Failed updating org:" slug) false)))

--- a/src/oc/storage/async/change.clj
+++ b/src/oc/storage/async/change.clj
@@ -38,7 +38,7 @@
    :change-at (or (:published-at content) (:created-at content))})
 
 (defn send-trigger! [trigger]
-  (timbre/info "Change notification request of" (:type trigger)
+  (timbre/info "Change notification request of" (:change-type trigger)
                "for" (:content-id trigger) "to queue" config/aws-sqs-change-queue)
   (timbre/trace "Change request:" trigger)
   (schema/validate ChangeTrigger trigger)

--- a/src/oc/storage/async/notification.clj
+++ b/src/oc/storage/async/notification.clj
@@ -41,8 +41,8 @@
   update - the content-id should be refreshed, this happens when a board or entry is updated
   delete - the specified content-id is deleted, this happens when a board or entry is removed
 
-  The notification trigger contains the type of resource as `resource-type` and the current resource as `current`. If
-  the trigger is for an update it will also contain the updated resource as `update`. 
+  The notification trigger contains the type of resource as `resource-type` and the content as `new` and/or
+  `old` in a key called `content`.
 
   The user whose actions triggered the notification is included as `user`.
 
@@ -50,12 +50,15 @@
   "
   {:notification-type (schema/pred notification-type?)
    :resource-type (schema/pred resource-type?)
-   :current (schema/conditional #(= (resource-type %) :entry) common-res/Entry
-                                #(= (resource-type %) :board) common-res/Board
-                                :else common-res/Org)
-   (schema/optional-key :update) (schema/conditional #(= (resource-type %) :entry) common-res/Entry
-                                                     #(= (resource-type %) :board) common-res/Board
-                                                     :else common-res/Org)
+   (schema/optional-key :org) common-res/Org
+   (schema/optional-key :board) common-res/Board   
+   :content {
+    (schema/optional-key :new) (schema/conditional #(= (resource-type %) :entry) common-res/Entry
+                                                   #(= (resource-type %) :board) common-res/Board
+                                                   :else common-res/Org)
+    (schema/optional-key :old) (schema/conditional #(= (resource-type %) :entry) common-res/Entry
+                                                   #(= (resource-type %) :board) common-res/Board
+                                                   :else common-res/Org)}
    :user lib-schema/User
    :notification-at lib-schema/ISO8601})
 
@@ -97,31 +100,26 @@
 
 ;; ----- Notification triggering -----
 
-(defun ->trigger
-  
-  ([notification-type :guard notification-type? content :guard map? user :guard map?]
-  (->trigger notification-type (resource-type content) content user))
-  
-  ([notification-type :guard #(= % :update) content :guard map? updated-content :guard map? user :guard map?]
-  (->trigger notification-type (resource-type content) content updated-content user))
-  
-  ([notification-type :guard notification-type? resource-type :guard resource-type?
-    content :guard map? user :guard map?]
-  {:notification-type notification-type
-   :resource-type resource-type
-   :current content
-   :user user
-   :notification-at (oc-time/current-timestamp)})
-
-  ([notification-type :guard #(= % :update) resource-type :guard resource-type?
-    content :guard map? updated-content :guard map? user :guard map?]
-  (assoc (->trigger notification-type resource-type content user) :update updated-content)))
+(defn ->trigger 
+  ([notification-type content user] (->trigger notification-type nil nil content user))
+  ([notification-type org content user] (->trigger notification-type org nil content user))
+  ([notification-type org board content user]
+  (let [notice {:notification-type notification-type
+                :resource-type (resource-type (or (:old content) (:new content)))
+                :content content
+                :user user
+                :notification-at (oc-time/current-timestamp)}
+        org-notice (if org (assoc notice :org org) notice)
+        final-notice (if board (assoc org-notice :board board) org-notice)]
+      final-notice)))
 
 (schema/defn ^:always-validate send-trigger! [trigger :- NotificationTrigger]
   (if (clojure.string/blank? config/aws-sns-storage-topic-arn)
-    (timbre/debug "Skipping a notification for:" (-> trigger :current :uuid))
+    (timbre/debug "Skipping a notification for:" (or (-> trigger :content :old :uuid)
+                                                     (-> trigger :content :new :uuid)))
     (do
-      (timbre/debug "Triggering a notification for:" (-> trigger :current :uuid))
+      (timbre/debug "Triggering a notification for:" (or (-> trigger :content :old :uuid)
+                                                         (-> trigger :content :new :uuid)))
       (>!! notification-chan trigger))))
 
 ;; ----- Component start/stop -----


### PR DESCRIPTION
No trello card.

This PR reworks the SNS notification payload and does some minor refactoring around the same. The payload now includes the org and board (where appropriate) and the description of the content is put in consistent keys of `old` and/or `new` in the `content` key. Also the publication of a draft now gets an event (was left out).

- [ ] Review the codes

Next, do some config:

- [ ] Configure SNS notifications for your local storage service by defining the ENV var `AWS_SNS_STORAGE_TOPIC_ARN` and pointing it at your SNS topic's ARN (one is already defined for each dev)
- [ ] Subscribe to your SNS w/ your email (normal, not JSON) and click the confirm link on the email that comes (make sure you remember to delete this subscription when you are done testing or it'll drive you batty)

Try out changes in storage that get notifications, and check the payloads in your email:

- [ ] entry post (new)
- [ ] entry post (from draft)
- [ ] entry save draft (gets no event!)
- [ ] entry update
- [ ] entry delete
- [ ] board create
- [ ] board update
- [ ] board delete
- [ ] org create
- [ ] org update

All good. Merge. This is already on both staging and beta (powering the Slack activity notifier) so no deployment needs.