### PR TITLE
Fix for not querying all entries.

### DIFF
--- a/src/oc/storage/util/search.clj
+++ b/src/oc/storage/util/search.clj
@@ -48,11 +48,11 @@
   (let [now (db-common/current-timestamp)]
     (doseq [org (org-res/list-orgs conn [:team-id])]
       (let [boards (board-res/list-boards-by-org conn (:uuid org) [:access])
-            allowed-boards (vec (map :uuid boards))
-            entries (entry-res/list-entries-by-org conn (:uuid org) :desc now :before allowed-boards)]
-        (doseq [entry entries]
-          (let [board (first (filter #(= (:uuid %) (:board-uuid entry)) boards))]
-            (send-trigger! (->trigger "entry" entry org board))))))))
+            allowed-boards (vec (map :uuid boards))]
+        (doseq [board boards]
+          (let [entries (entry-res/list-entries-by-board conn (:uuid board))]
+            (doseq [entry entries]
+              (send-trigger! (->trigger "entry" entry org board)))))))))
 
 ;; ----- CLI -----
 


### PR DESCRIPTION
https://trello.com/c/vKVYCYMZ

This change uses `list-entries-by-board` so you don't hit the limit used in `list-entries-by-org`.