### PR TITLE
Async pattern

### DIFF
--- a/src/dev.clj
+++ b/src/dev.clj
@@ -19,11 +19,12 @@
 (defn bind-conn! []
   (alter-var-root #'conn (constantly (pool/claim (get-in system [:db-pool :pool])))))
 
-(defn start []
+(defn- start⬆ []
   (alter-var-root #'system component/start))
 
 (defn stop []
-  (alter-var-root #'system (fn [s] (when s (component/stop s)))))
+  (alter-var-root #'system (fn [s] (when s (component/stop s))))
+  (println (str "\nWhen you're ready to start the system again, just type: (go)\n")))
 
 (defn go
   
@@ -31,7 +32,7 @@
   
   ([port]
   (init port)
-  (start)
+  (start⬆)
   (bind-conn!)
   (app/echo-config port)
   (println (str "Now serving storage from the REPL.\n"

--- a/src/oc/storage/async/notification.clj
+++ b/src/oc/storage/async/notification.clj
@@ -2,7 +2,7 @@
   "
   Async publish of notification events to AWS SNS.
   "
-  (:require [clojure.core.async :as async :refer (<!! >!!)]
+  (:require [clojure.core.async :as async :refer (<! >!!)]
             [taoensso.timbre :as timbre]
             [cheshire.core :as json]
             [amazonica.aws.sns :as sns]
@@ -87,7 +87,7 @@
   (timbre/info "Starting notification...")
   (async/go (while @notification-go
     (timbre/debug "Notification waiting...")
-    (let [message (<!! notification-chan)]
+    (let [message (<! notification-chan)]
       (timbre/debug "Processing message on notification channel...")
       (if (:stop message)
         (do (reset! notification-go false) (timbre/info "Notification stopped."))


### PR DESCRIPTION
No Trello card.

Just cleans up our use of the core.async producer/consumer pattern we have throughout many of the services with a parked, rather than a blocked read.

Also discourages use of `(start)` at the REPL and improves component life-cycle logging.

To test:

- [x] Review the codes
- [ ] Fire up the REPL
- [x] `(go) (stop) (go)` sequence. All components start propertly, stop properly, start properly?
- [x] Start service up with `lein start`, just as good as REPL's `(go)`?
- [x] Create some new content, SNS message went out to search service OK?
- [ ] Merge
- [ ] Deploy
- [ ] Knit some tiny socks for homeless cats