### PR TITLE
Send user data with board changes.

### DIFF
--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -206,7 +206,6 @@
             (remove-member conn ctx (:slug org) (:slug updated-result) :viewers viewer))))
       (let [final-result (board-res/get-board conn (:uuid updated-result))]
         (change/send-trigger! (change/->trigger :update final-result))
-        (timbre/debug notifications)
         (notification/send-trigger! (notification/->trigger :update org {:old board :new final-result :notifications notifications} user))
         {:updated-board final-result}))
 

--- a/src/oc/storage/async/notification.clj
+++ b/src/oc/storage/async/notification.clj
@@ -50,11 +50,12 @@
   {:notification-type (schema/pred notification-type?)
    :resource-type (schema/pred resource-type?)
    (schema/optional-key :org) common-res/Org
-   (schema/optional-key :board) common-res/Board   
+   (schema/optional-key :board) common-res/Board
    :content {
     (schema/optional-key :new) (schema/conditional #(= (resource-type %) :entry) common-res/Entry
                                                    #(= (resource-type %) :board) common-res/Board
                                                    :else common-res/Org)
+    (schema/optional-key :notifications) (schema/maybe [common-res/User])
     (schema/optional-key :old) (schema/conditional #(= (resource-type %) :entry) common-res/Entry
                                                    #(= (resource-type %) :board) common-res/Board
                                                    :else common-res/Org)}

--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -110,5 +110,4 @@
    :first-name schema/Str
    :status schema/Str
    :created-at lib-schema/ISO8601
-   schema/Keyword schema/Any ; and whatever else
-   })
+   schema/Keyword schema/Any}) ; and whatever else

--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -99,3 +99,16 @@
 
   :created-at lib-schema/ISO8601
   :updated-at lib-schema/ISO8601})
+
+(def User
+  "User info to notify via email/slack"
+  {:updated-at lib-schema/ISO8601
+   :email schema/Str
+   :last-name schema/Str
+   :avatar-url schema/Str
+   :user-id lib-schema/UniqueID
+   :first-name schema/Str
+   :status schema/Str
+   :created-at lib-schema/ISO8601
+   schema/Keyword schema/Any ; and whatever else
+   })


### PR DESCRIPTION
Send board notifications over SNS so the bot and email service can notify users of changes.

See testing instructions:
https://github.com/open-company/open-company-auth/pull/28