### PR TITLE
Remove user and org favorite reactions.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
     ;; Utility functions https://github.com/weavejester/medley
     [medley "1.0.0"]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
-    [zprint "0.4.6"]
+    [zprint "0.4.7"]
     
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     [open-company/lib "0.16.2"]
@@ -82,7 +82,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.2-alpha2" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.2-alpha3" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]
@@ -126,7 +126,7 @@
         ;; Dead code finder https://github.com/venantius/yagni
         [venantius/yagni "0.1.4" :exclusions [org.clojure/clojure]]
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
-        [lein-zprint "0.3.7" :exclusions [org.clojure/clojure]]
+        [lein-zprint "0.3.8" :exclusions [org.clojure/clojure]]
       ]  
     }]
     :repl-config [:dev {

--- a/src/oc/storage/api/activity.clj
+++ b/src/oc/storage/api/activity.clj
@@ -152,7 +152,7 @@
                              board-slugs-and-names (map #(array-map :slug (:slug %) :name (:name %)) boards)
                              board-by-uuid (zipmap board-uuids board-slugs-and-names)
                              activity (assemble-activity conn params org board-by-uuid allowed-boards)]
-                          (activity-rep/render-activity-list conn params org activity (:access-level ctx) user-id))))
+                          (activity-rep/render-activity-list params org activity (:access-level ctx) user-id))))
 
 ;; Calendar not used right now
 ;; A resource for operations on the calendar of activity for a particular Org

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -58,9 +58,7 @@
   ;; Regular board
   ([conn org :guard map? board :guard map? ctx]
   (let [org-slug (:slug org)
-        org-id (:uuid org)
         slug (:slug board)
-        user-id (-> ctx :user :user-id)
         entries (entry-res/list-entries-by-board conn (:uuid board)) ; all entries for the board
         board-topics (->> entries
                         (map #(select-keys % [:topic-slug :topic-name]))
@@ -73,8 +71,8 @@
                     all-topics) ; board's and default
         entry-reps (map #(entry-rep/render-entry-for-collection org board %
                             (comments %)
-                            (reaction-res/reactions-with-favorites conn org-id user-id (reactions %))
-                            (:access-level ctx) user-id)
+                            (reaction-res/aggregate-reactions (reactions %))
+                            (:access-level ctx) (-> ctx :user :user-id))
                       entries)]
     (assemble-board org-slug (assoc board :topics topics) entry-reps ctx)))
 

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -92,7 +92,6 @@
 (defonce default-reactions [])
 
 (defonce max-reaction-count 5) 
-(defonce max-favorite-reaction-count 3)
 
 (defonce inline-comment-count 10)
 

--- a/src/oc/storage/representations/activity.clj
+++ b/src/oc/storage/representations/activity.clj
@@ -73,9 +73,8 @@
   Given an org and a sequence of entry maps, create a JSON representation of a list of
   activity for the API.
   "
-  [conn params org activity access-level user-id]
-  (let [org-id (:uuid org)
-        collection-url (url org params)
+  [params org activity access-level user-id]
+  (let [collection-url (url org params)
         links [(hateoas/self-link collection-url {:accept mt/activity-collection-media-type})
                (hateoas/up-link (org-rep/url org) {:accept mt/org-media-type})]
         full-links (concat links (pagination-links org params activity))]
@@ -85,7 +84,7 @@
                     :links full-links
                     :items (map #(render-activity-for-collection org %
                                     (comments %)
-                                    (reaction-res/reactions-with-favorites conn org-id user-id (reactions %))
+                                    (reaction-res/aggregate-reactions (reactions %))
                                     access-level user-id) (:activity activity))}}
       {:pretty config/pretty?})))
 

--- a/src/oc/storage/resources/reaction.clj
+++ b/src/oc/storage/resources/reaction.clj
@@ -1,45 +1,4 @@
-(ns oc.storage.resources.reaction
-  (:require [clojure.core.cache :as cache]
-            [taoensso.timbre :as timbre]
-            [oc.lib.db.common :as db-common]
-            [oc.storage.config :as config]))
-
-;; ----- Favorite Reaction cache -----
-
-(defonce empty-cache (cache/ttl-cache-factory {} :ttl (* 5 60 1000))) ; TTL of 5 minutes
-(defonce FavoriteReactionCache (atom empty-cache))
-
-;; ----- Favorite Reactions -----
-
-(defn- favorites
-  [conn uuid field]
-  (if-let [cached-response (cache/lookup @FavoriteReactionCache uuid)]
-    (do
-      (timbre/trace "Favorites cache hit for" (str field ":") uuid)
-      cached-response)
-    (do
-      (timbre/trace "Favorites cache miss for" (str field ":") uuid)
-      (let [favs (vec (map first
-                  (db-common/grouped-resources-by-most-common conn "interactions" field
-                                                              uuid "reaction" config/max-favorite-reaction-count)))]
-        (reset! FavoriteReactionCache (cache/miss @FavoriteReactionCache uuid favs))
-        favs))))
-
-(defn- org-favorites
-  "
-  Return the most favorite reactions (by number of times used) for the specified org.
-
-  Results will be used from a TTL cache.
-  "
-  [conn org-id] (favorites conn org-id "org-uuid"))
-
-(defn- user-favorites
-  "
-  Return the most favorite reactions (by number of times used) for the specified user.
-
-  Results will be used from a TTL cache.
-  "
-  [conn user-id] (favorites conn user-id "author-uuid"))
+(ns oc.storage.resources.reaction)
 
 (defn- reaction-collapse
   "Reducer function that collapses reactions into count and sequence of author based on common reaction unicode."
@@ -56,28 +15,10 @@
       ;; haven't seen this reaction unicode before, so init a new one
       (assoc reactions unicode {:reaction unicode :count 1 :authors [author] :author-ids [author-id]}))))
 
-(defn reactions-with-favorites
+(defn aggregate-reactions
   "
   Given a sequence of individual reaction interactions, collapse it down to a set of distinct reactions
-  that include the count of how many times reacted and the list of author names and IDs that reacted, and
-  supplement this list with user favorites (at count 0) if needed, and org favorites (at count 0) if needed.
+  that include the count of how many times reacted and the list of author names and IDs that reacted.
   "
-  [conn org-id user-id entry-reactions]
-  (let [reactions (or (vals (reduce reaction-collapse {} (map #(assoc % :count 1) entry-reactions))) [])
-        reaction-unicodes (set (map :reaction reactions))
-        needed-user-favs (- config/max-favorite-reaction-count (count reactions))
-        ;; user's favorite reactions if we need them
-        user-favs (when (and user-id (pos? needed-user-favs))
-                      (user-favorites conn user-id))
-        filtered-user-favs (remove reaction-unicodes user-favs)
-        reactions-and-user-favs (concat reactions
-                                         (map #(hash-map :reaction % :count 0 :authors [] :author-ids [])
-                                            (take needed-user-favs filtered-user-favs)))
-        ; org's favorite reactions if we need them
-        reaction-unicodes (set (map :reaction reactions-and-user-favs))
-        needed-org-favs (- config/max-favorite-reaction-count (count reactions-and-user-favs))
-        org-favs (when (and org-id (pos? needed-org-favs))
-                    (org-favorites conn org-id))
-        filtered-org-favs (remove reaction-unicodes org-favs)]
-    (concat reactions-and-user-favs (map #(hash-map :reaction % :count 0 :authors [] :author-ids[])
-                                        (take needed-org-favs filtered-org-favs)))))
+  [entry-reactions]
+  (or (vals (reduce reaction-collapse {} (map #(assoc % :count 1) entry-reactions))) []))


### PR DESCRIPTION
https://trello.com/c/mOvOdYTQ

This PR removes server-side user and org favorite reactions. We're now relying on just the recent used stuff from emoji mart.

To test:

- [x] Review the code
- [x] Do a reaction regression test with the UI
- [x] Create reactions, remove reactions, as multiple users, w/ refreshes to so server data is coming from storage, not just interaction service
- [ ] Merge
- [ ] Deploy
- [ ] Sharpen your kitchen knives