### PR TITLE
Return of the Attachments.

### DIFF
--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -70,7 +70,8 @@
           props (if new-board-uuid
                   (assoc entry-props :board-uuid new-board-uuid)
                   (dissoc entry-props :board-uuid))
-          updated-entry (merge existing-entry (entry-res/ignore-props props))]
+          merged-entry (merge existing-entry (entry-res/ignore-props props))
+          updated-entry (update merged-entry :attachments #(entry-res/timestamp-attachments %))]
       (if (lib-schema/valid? common-res/Entry updated-entry)
         {:existing-entry existing-entry :updated-entry updated-entry}
         [false, {:updated-entry updated-entry}])) ; invalid update

--- a/src/oc/storage/representations/entry.clj
+++ b/src/oc/storage/representations/entry.clj
@@ -14,7 +14,7 @@
                        :logo-width :org-logo-width
                        :logo-height :org-logo-height})
 
-(def representation-props [:uuid :topic-name :topic-slug :headline :body :status
+(def representation-props [:uuid :topic-name :topic-slug :headline :body :attachments :status
                            :org-name :org-slug :org-logo-url :org-logo-width :org-logo-height
                            :board-uuid :board-slug :board-name
                            :team-id :author :publisher :published-at :created-at :updated-at])

--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -21,6 +21,13 @@
 
 (def Slug "Valid slug used to uniquely identify a resource in a visible URL." (schema/pred slug/valid-slug?))
 
+-(def Attachment {
+  :file-name lib-schema/NonBlankStr
+  :file-type lib-schema/NonBlankStr
+  :file-size schema/Num
+  :file-url lib-schema/NonBlankStr
+  :created-at lib-schema/ISO8601})
+
 (def ContributingAuthor
   "An author in a sequence of Authors involved in creating content."
   (merge lib-schema/Author {:updated-at lib-schema/ISO8601}))
@@ -88,6 +95,9 @@
   :headline schema/Str
   :body schema/Str
   
+  ;; Attachments
+  (schema/optional-key :attachments) [Attachment]
+
   ;; Comment sync
   (schema/optional-key :slack-thread) lib-schema/SlackThread
 

--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -21,7 +21,7 @@
 
 (def Slug "Valid slug used to uniquely identify a resource in a visible URL." (schema/pred slug/valid-slug?))
 
--(def Attachment {
+(def Attachment {
   :file-name lib-schema/NonBlankStr
   :file-type lib-schema/NonBlankStr
   :file-size schema/Num

--- a/src/oc/storage/resources/entry.clj
+++ b/src/oc/storage/resources/entry.clj
@@ -46,6 +46,13 @@
       (assoc :publisher author))
     entry))
 
+(defn timestamp-attachments
+  "Add a `:created-at` timestamp with the specified value to any attachment that's missing it."
+  ([attachments] (timestamp-attachments attachments (db-common/current-timestamp)))
+ 
+  ([attachments timestamp]
+  (map #(if (:created-at %) % (assoc % :created-at timestamp)) attachments)))
+
 ;; ----- Entry CRUD -----
 
 (schema/defn ^:always-validate ->entry :- common/Entry
@@ -73,6 +80,7 @@
           (update :topic-name #(or % nil))
           (update :headline #(or % ""))
           (update :body #(or % ""))
+          (update :attachments #(timestamp-attachments % ts))
           (assoc :org-uuid (:org-uuid board))
           (assoc :board-uuid board-uuid)
           (assoc :author [(assoc author :updated-at ts)])
@@ -155,7 +163,9 @@
           slugged-entry (assoc topic-named-entry :topic-slug topic-slug)
           ts (db-common/current-timestamp)
           updated-authors (concat authors [(assoc (lib-schema/author-for-user user) :updated-at ts)])
-          updated-entry (assoc slugged-entry :author updated-authors)]
+          attachments (:attachments merged-entry)
+          updated-attachments (assoc slugged-entry :attachments (timestamp-attachments attachments ts))
+          updated-entry (assoc updated-attachments :author updated-authors)]
       (schema/validate common/Entry updated-entry)
       (db-common/update-resource conn table-name primary-key original-entry updated-entry ts))))
 


### PR DESCRIPTION
https://trello.com/c/kjfhXr7U

This is to support a Web PR that doesn't exist yet, which pulls attachments out of the body prop and into their own sequence like we've had them before.

Review with [Web/attachments#396](https://github.com/open-company/open-company-web/pull/396)

- [x] Review the code

Test with the new Web work when it's ready: 

- [x] On create add a single attachment
- [x] On create add multiple attachments
- [x] On edit add a single attachment
- [x] On edit add multiple attachments
- [x] On edit add a single attachment to existing
- [x] On edit add multiple attachments to existing
- [x] On edit delete only a single attachment
- [x] On edit delete some multiple attachments, but not all
- [x] On edit delete all the multiple attachments
- [x] On edit delete some of the multiple attachments
- [x] On edit delete some of the multiple attachments and add others
- [ ] Merge
- [ ] Deploy
- [ ] Adopt a ferret
