### PR TITLE
upsert entry support when creating a new board.

### DIFF
--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -170,10 +170,13 @@
       (doseq [viewer viewers] (add-member conn ctx (:slug org) (:slug board-result) :viewers viewer))
       ;; Add any entries specified in the request
       (doseq [entry entries]
-          (timbre/info "Creating entry for new board:" board-uuid)
-          (let [entry-result (entry-res/create-entry! conn
-                              (entry-res/->entry conn board-uuid (assoc entry :status "published") user))]
-            (timbre/info "Created entry for new board:" board-uuid "as" (:uuid entry-result))))
+        (let [new-entry (-> entry
+                            (assoc :status "published")
+                            (assoc :board-uuid board-uuid))]
+          (timbre/info "Upserting entry for new board:" board-uuid)
+          (let [entry-result (entry-res/upsert-entry! conn
+                 (entry-res/->entry conn board-uuid new-entry user) user)]
+            (timbre/info "Upserted entry for new board:" board-uuid "as" (:uuid entry-result)))))
       (let [created-board (if (and (empty? authors) (empty? viewers))
                             ;; no additional members added, so using the create response is good
                             board-result

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -93,7 +93,7 @@
   [conn entry author]
   (if-let* [entry-uuid (:uuid entry)
            found-entry (entry-res/get-entry conn entry-uuid)]
-    found-entry
+    entry
     (entry-res/->entry conn entry-res/temp-uuid entry author)))
 
 (defn- valid-new-board? [conn org-slug {board-map :data author :user}]

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -93,7 +93,7 @@
   [conn entry author]
   (if-let* [entry-uuid (:uuid entry)
            found-entry (entry-res/get-entry conn entry-uuid)]
-    entry
+    (merge found-entry entry)
     (entry-res/->entry conn entry-res/temp-uuid entry author)))
 
 (defn- valid-new-board? [conn org-slug {board-map :data author :user}]

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -91,7 +91,8 @@
 ;; ----- Validations -----
 (defn- valid-entry-with-board?
   [conn entry author]
-  (if-let [found-entry (entry-res/get-entry conn (:uuid entry))]
+  (if-let* [entry-uuid (:uuid entry)
+           found-entry (entry-res/get-entry conn entry-uuid)]
     found-entry
     (entry-res/->entry conn entry-res/temp-uuid entry author)))
 

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -179,7 +179,7 @@
         (let [fixed-entry (-> entry
                               (assoc :status "published")
                               (assoc :board-uuid board-uuid))
-              new-entry (if (:uuid entry)
+              new-entry (if (entry-res/get-entry conn (:uuid entry))
                           fixed-entry
                           (entry-res/->entry conn board-uuid fixed-entry user))]
           (timbre/info "Upserting entry for new board:" board-uuid)

--- a/src/oc/storage/resources/entry.clj
+++ b/src/oc/storage/resources/entry.clj
@@ -173,6 +173,15 @@
       (schema/validate common/Entry updated-entry)
       (db-common/update-resource conn table-name primary-key original-entry updated-entry ts))))
 
+(defn upsert-entry!
+  "
+  If entry is found update otherwise create the new entry.
+  "
+  [conn entry user]
+  (if-let [original-entry (get-entry conn (:uuid entry))]
+    (update-entry! conn (:uuid entry) entry user)
+    (create-entry! conn entry)))
+
 (schema/defn ^:always-validate publish-entry! :- (schema/maybe common/Entry)
   "
   Given the UUID of the entry, an optional updated entry map, and a user (as the publishing author),


### PR DESCRIPTION
This will allow a user to move an existing entry to a newly created board.

