### PR TITLE
In addition to the draft count also add the entry count for each board.

### DIFF
--- a/src/oc/storage/api/orgs.clj
+++ b/src/oc/storage/api/orgs.clj
@@ -199,7 +199,7 @@
                              full-boards (if (pos? draft-entry-count)
                                             (conj allowed-boards (board-res/drafts-board org-id user))
                                             allowed-boards)
-                             board-reps (map #(board-rep/render-board-for-collection slug % draft-entry-count)
+                             board-reps (map #(board-rep/render-board-for-collection slug % draft-entry-count (count (entry-res/list-entries-by-board conn (:uuid %))))
                                           full-boards)
                              authors (:authors org)
                              author-reps (map #(org-rep/render-author-for-collection org % (:access-level ctx)) authors)]
@@ -297,7 +297,7 @@
                                   org-id (:uuid new-org)
                                   user-id (-> ctx :user :user-id)
                                   boards (board-res/list-boards-by-org conn org-id [:created-at :updated-at])
-                                  board-reps (map #(board-rep/render-board-for-collection slug % 0)
+                                  board-reps (map #(board-rep/render-board-for-collection slug % 0 0)
                                                 (map #(assoc % :access-level :author) boards))
                                   author-reps [(org-rep/render-author-for-collection new-org user-id :author)]
                                   org-for-rep (-> new-org

--- a/src/oc/storage/representations/board.clj
+++ b/src/oc/storage/representations/board.clj
@@ -50,9 +50,9 @@
   (hateoas/link-map "interactions" "GET"
     (str config/interaction-server-ws-url "/interaction-socket/boards/" board-uuid) nil))
 
-(defn- board-collection-links [board org-slug draft-count]
+(defn- board-collection-links [board org-slug entry-count]
   (let [board-slug (:slug board)
-        options (if (zero? draft-count) {} {:count draft-count})
+        options (if (zero? entry-count) {} {:count entry-count})
         links [(self-link org-slug board-slug options)]
         full-links (if (or (= :author (:access-level board))
                            (= board-slug "drafts"))
@@ -97,10 +97,10 @@
 
 (defn render-board-for-collection
   "Create a map of the board for use in a collection in the REST API"
-  ([org-slug board] (render-board-for-collection org-slug board 0))
+  ([org-slug board] (render-board-for-collection org-slug board 0 0))
 
-  ([org-slug board draft-entry-count]
-  (let [this-board-count (if (= (:uuid board) (:uuid board-res/default-drafts-board)) draft-entry-count 0)]
+  ([org-slug board draft-entry-count entry-count]
+  (let [this-board-count (if (= (:uuid board) (:uuid board-res/default-drafts-board)) draft-entry-count entry-count)]
     (-> board
       (select-keys (conj representation-props :access-level))
       (board-collection-links org-slug this-board-count)


### PR DESCRIPTION
Trello: https://trello.com/c/xu50HxqM/1224-count-prop-on-all-board-self-links-from-org

Entry counts for each board in the organization will be returned in the API request.  To test view the results from an API request in the browser.