### PR TITLE
add back the auto share on publish after publishing a draft.

### DIFF
--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -165,6 +165,7 @@
             publish-result (entry-res/publish-entry! conn (:uuid updated-entry) updated-entry user)]
     (do
       (timbre/info "Published entry for:" (:uuid updated-entry))
+      (auto-share-on-publish conn ctx publish-result)
       (change/send-trigger! (change/->trigger :add publish-result))
       (timbre/info "Published entry:" entry-for)
       (notification/send-trigger! (notification/->trigger :add org board {:new publish-result} user))


### PR DESCRIPTION
This change adds back the auto share to slack on publish.

To test:
- create  a section that auto shares to slack
- create a post and save it as a draft
- [x] No slack notification
- edit the draft and post it
- [x] Do you get a notification in the slack channel?
- create a post and post instead of saving as draft
- [x] Do you get a notification in the slack channel?
