### PR TITLE
BUGFIX: create a new post within a new section doesn't work

### DIFF
--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -194,7 +194,7 @@
               (when (= :add entry-action)
                 (entries-api/auto-share-on-publish conn (assoc ctx :existing-board board-result) entry-result))
               (change/send-trigger! (change/->trigger entry-action entry-result))
-              (notification/send-trigger! (notification/->trigger entry-action org board-result {:new entry-result} (:user ctx)))))))
+              (notification/send-trigger! (notification/->trigger entry-action org board-result {:new entry-result} (:user ctx) nil))))))
       (let [created-board (if (and (empty? authors) (empty? viewers))
                             ;; no additional members added, so using the create response is good
                             board-result


### PR DESCRIPTION
Bug:
- click Compose
- click on the current section name
- click Add a new section
- add a new section name
- click Create
- add the post title
- add the post body
- click Post
- error!

The notification trigger was still using the old form w/o the note at the end so it was creating an erroneous payload for the notification.

To test:
- repeat the test above with this branch
- [x] did it work? Good
- now repeat it but select private board and add another user and a personal note
- [x] did you receive the invitation to the private board with the personal note? Good