### PR TITLE
Optional file type for attachments

### DIFF
--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -23,7 +23,7 @@
 
 (def Attachment {
   :file-name lib-schema/NonBlankStr
-  :file-type lib-schema/NonBlankStr
+  :file-type (schema/maybe schema/Str)
   :file-size schema/Num
   :file-url lib-schema/NonBlankStr
   :created-at lib-schema/ISO8601})


### PR DESCRIPTION
Right now the file-type property of post attachments is required to be not empty. It's possible that Filestack return an empty file-type when used to upload a file.

To test:
- create a new post
- add an attachment
- select clojure file (with .clj extention)
- filestack should upload it and read it with empty file type
- save the post
- [x] did it save? Good
- [x] did you NOT get a 422 on saving? Good
- go back to the board or AP
- check the board/AP refresh
- [x] the file has no file-type: null or ""? Good