### PR TITLE
Fix moving board

### DIFF
--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -173,11 +173,10 @@
   (if-let* [user (:user ctx)
             org (:existing-org ctx)
             board (:existing-board ctx)
-            old-board (:moving-board ctx)
             entry (:existing-entry ctx)
             updated-entry (:updated-entry ctx)
             publish-result (entry-res/publish-entry! conn (:uuid updated-entry) updated-entry user)]
-    (do
+    (let [old-board (:moving-board ctx)]
       (undraft-board conn user org board)
       ;; If we are moving the entry from a draft board, check if we need to remove the board itself.
       (when old-board

--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -153,12 +153,11 @@
   (timbre/info "Updating entry for:" entry-for)
   (if-let* [org (:existing-org ctx)
             board (:existing-board ctx)
-            old-board (:moving-board ctx)
             user (:user ctx)
             entry (:existing-entry ctx)
             updated-entry (:updated-entry ctx)
             updated-result (entry-res/update-entry! conn (:uuid updated-entry) updated-entry user)]
-    (do
+    (let [old-board (:moving-board ctx)]
       ;; If we are moving the entry from a draft board, check if we need to remove the board itself.
       (when old-board
         (let [remaining-entries (entry-res/list-all-entries-by-board conn (:uuid old-board))]


### PR DESCRIPTION
On most entry updates the key `:moving-board` is going to be empty since the user didn't move the board.
I made sure that the `moving-board` is retrieved out of the `if-let` so the entry update won't fail.

Slack: https://sentry.io/opencompany/oc-staging-storage/issues/593780255/?referrer=slack

I'm not sure how to test this, the best thing would be to send a PATCH request for an entry w/o a board-slug specified in the entry map, this shouldn't trigger an error.