### PR TITLE
Bugfix: public boards are not visible to anonymous users

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -82,7 +82,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.2-alpha4" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.2" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]
@@ -90,7 +90,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.7"]
+        [jonase/eastwood "0.2.9"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -301,12 +301,11 @@
   :exists? (fn [ctx] (if-let* [_slugs? (and (slugify/valid-slug? org-slug) (slugify/valid-slug? slug))
                                org (or (:existing-org ctx) (org-res/get-org conn org-slug))
                                org-uuid (:uuid org)
-                               user (:user ctx)
                                board (or (:existing-board ctx)
                                          (if (and (= slug (:slug board-res/default-drafts-board))
-                                                  (lib-schema/valid? lib-schema/User user))
+                                                  (lib-schema/valid? lib-schema/User (:user ctx)))
                                             ;; Draft board for the user
-                                            (board-res/drafts-board org-uuid user)
+                                            (board-res/drafts-board org-uuid (:user ctx))
                                             ;; Regular board by slug
                                             (board-res/get-board conn org-uuid slug)))]
                         {:existing-org org :existing-board board}


### PR DESCRIPTION
Bug: with incognito visit a public board, do you not see it? Not good.

Fix: avoid requiring a user to retrieve a board.

To test:
- login
- go to a board
- set it to be public
- now refresh
- [x] do you still see it? Good
- create a draft
- visit the draft board
- [x] do you see it? Good
- copy the public board url
- logout
- visit the public board
- [x] do you see it? Good
- now visit a team or public board
- [x] do you NOT see it? Good
- [x] do you NOT see errors in the storage console? Good