### PR TITLE
Post versions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,19 @@
 Copyright © 2015-2018 OpenCompany, LLC.
 
+"Commons Clause" License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, the right to Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software. Any license notice or attribution required by the License must also include this Commons Cause License Condition notice.
+
+Software: Open Company Storage
+
+License: Mozilla Public License, version 2.0
+
+Licensor: OpenCompany, LLC
+
 Mozilla Public License, version 2.0
 
 1. Definitions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # [OpenCompany](https://github.com/open-company) Storage Service
 
-[![MPL License](http://img.shields.io/badge/license-MPL-blue.svg?style=flat)](https://www.mozilla.org/MPL/2.0/)
 [![Build Status](http://img.shields.io/travis/open-company/open-company-storage.svg?style=flat)](https://travis-ci.org/open-company/open-company-storage)
 [![Dependencies Status](https://versions.deps.co/open-company/open-company-storage/status.svg)](https://versions.deps.co/open-company/open-company-storage)
 
@@ -12,7 +11,7 @@
 
 Companies struggle to keep everyone on the same page. People are hyper-connected in the moment with chat apps, but as teams grow chat gets noisy and people miss key information. Chat might be ideal for spontaneous conversations, but it’s terrible for the more substantial discussions that aren’t meant to be urgent. The solution - **focused conversations that build transparency and alignment**.
 
-OpenCompany is the open source platform that powers [Carrot](https://carrot.io), a SaaS app for building transparency and alignment. With Carrot, important company updates, announcements, stories, and strategic plans create focused, topic-based conversations that keep everyone aligned without interruptions.
+OpenCompany is the source-available platform that powers [Carrot](https://carrot.io), a SaaS app for building transparency and alignment. With Carrot, important company updates, announcements, stories, and strategic plans create focused, topic-based conversations that keep everyone aligned without interruptions.
 
 Transparency expectations are changing. Organizations need to change as well if they are going to attract and retain savvy teams. Just as open source changed the way we build software, transparency changes how we build successful companies with information that is open, interactive, and always accessible. **Carrot turns transparency into a competitive advantage**.
 
@@ -397,6 +396,8 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 ## License
 
-Distributed under the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/).
-
 Copyright © 2015-2018 OpenCompany, LLC.
+
+Distributed under the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/) with the [Commons Clause](https://commonsclause.com/).
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [Commons Clause](https://commonsclause.com/) and the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/) for more details.

--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,8 @@
   :description "OpenCompany Storage Service"
   :url "https://github.com/open-company/open-company-storage"
   :license {
-    :name "Mozilla Public License v2.0"
-    :url "http://www.mozilla.org/MPL/2.0/"
+    :name "Mozilla Public License v2.0 with the Common Clause"
+    :url "https://github.com/open-company/open-company-storage/blob/mainline/LICENSE"
   }
 
   :min-lein-version "2.7.1"

--- a/src/oc/storage/db/migrations/1534797688142_entry_versions.edn
+++ b/src/oc/storage/db/migrations/1534797688142_entry_versions.edn
@@ -9,7 +9,6 @@
   (println "Creating table: " entry/versions-table-name)
   (println (m/create-table conn config/db-name entry/versions-table-name entry/versions-primary-key))
   (println (m/create-index conn entry/versions-table-name "revision-id"))
-  (println (m/create-index conn entry/versions-table-name "topic-slug"))
   (println (m/create-index conn entry/versions-table-name "board-uuid"))
   (println (m/create-index conn entry/versions-table-name "org-uuid"))
 

--- a/src/oc/storage/db/migrations/1534797688142_entry_versions.edn
+++ b/src/oc/storage/db/migrations/1534797688142_entry_versions.edn
@@ -7,7 +7,7 @@
 (defn up [conn]
 
   (println "Creating table: " entry/versions-table-name)
-  (println (m/create-table conn config/db-name entry/versions-table-name entry/primary-key))
+  (println (m/create-table conn config/db-name entry/versions-table-name entry/versions-primary-key))
   (println (m/create-index conn entry/versions-table-name "revision-id"))
   (println (m/create-index conn entry/versions-table-name "topic-slug"))
   (println (m/create-index conn entry/versions-table-name "board-uuid"))

--- a/src/oc/storage/db/migrations/1534797688142_entry_versions.edn
+++ b/src/oc/storage/db/migrations/1534797688142_entry_versions.edn
@@ -1,0 +1,22 @@
+(ns oc.storage.db.migrations.entry-versions
+  (:require [rethinkdb.query :as r]
+            [oc.lib.db.migrations :as m]
+            [oc.storage.config :as config]
+            [oc.storage.resources.entry :as entry]))
+
+(defn up [conn]
+
+  (println "Creating table: " entry/versions-table-name)
+  (println (m/create-table conn config/db-name entry/versions-table-name entry/primary-key))
+  (println (m/create-index conn entry/versions-table-name "revision-id"))
+  (println (m/create-index conn entry/versions-table-name "topic-slug"))
+  (println (m/create-index conn entry/versions-table-name "board-uuid"))
+  (println (m/create-index conn entry/versions-table-name "org-uuid"))
+
+  ;; create revision number in regular entry table
+  (println "Add new property (revision-id) to existing entries...")
+  (-> (r/table entry/table-name)
+      (r/update (r/fn [e] {:revision-id 0}))
+      (r/run conn))
+
+  true) ; return true on success

--- a/src/oc/storage/representations/entry.clj
+++ b/src/oc/storage/representations/entry.clj
@@ -20,7 +20,7 @@
                            :board-uuid :board-slug :board-name :video-id
                            :team-id :author :publisher :published-at :created-at
                            :video-transcript :video-processed :video-error
-                           :updated-at])
+                           :updated-at :revision-id])
 
 (defun url
 

--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -112,6 +112,7 @@
   (schema/optional-key :video-transcript) (schema/maybe schema/Str)
   (schema/optional-key :video-processed) (schema/maybe schema/Bool)
   (schema/optional-key :video-error) (schema/maybe schema/Bool)
+  (schema/optional-key :revision-id) schema/Int
   :created-at lib-schema/ISO8601
   :updated-at lib-schema/ISO8601})
 

--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -112,7 +112,7 @@
   (schema/optional-key :video-transcript) (schema/maybe schema/Str)
   (schema/optional-key :video-processed) (schema/maybe schema/Bool)
   (schema/optional-key :video-error) (schema/maybe schema/Bool)
-  (schema/optional-key :revision-id) schema/Int
+  :revision-id schema/Int
   :created-at lib-schema/ISO8601
   :updated-at lib-schema/ISO8601})
 

--- a/src/oc/storage/resources/entry.clj
+++ b/src/oc/storage/resources/entry.clj
@@ -89,6 +89,7 @@
           (assoc :org-uuid (:org-uuid board))
           (assoc :board-uuid board-uuid)
           (assoc :author [(assoc author :updated-at ts)])
+          (assoc :revision-id 0)
           (assoc :created-at ts)
           (assoc :updated-at ts)
           (publish-props ts author)))
@@ -141,9 +142,7 @@
                               entry)
           author (assoc (first (:author entry)) :updated-at ts)] ; update initial author timestamp
       ;; create the entry
-      (let [new-entry (db-common/create-resource conn table-name (assoc stamped-entry :author [author]) ts)]
-           ;; first version
-           (update-entry conn (assoc new-entry :revision-id 0) new-entry ts)))
+      (db-common/create-resource conn table-name (assoc stamped-entry :author [author]) ts))
     (throw (ex-info "Invalid board uuid." {:board-uuid (:board-uuid entry)}))))) ; no board
 
 (schema/defn ^:always-validate get-entry :- (schema/maybe common/Entry)

--- a/src/oc/storage/resources/entry.clj
+++ b/src/oc/storage/resources/entry.clj
@@ -115,10 +115,12 @@
 (declare get-entry)
 
 (defn- delete-version [conn uuid]
-  (let [entry (get-entry conn uuid)]
+  (let [entry (get-entry conn uuid)
+        revision-id (if (zero? (:revision-id entry))
+                      (inc (:revision-id entry))
+                      (:revision-id entry))]
     (create-version conn entry (-> entry
-                                   (assoc :revision-id
-                                          (inc (:revision-id entry)))
+                                   (assoc :revision-id revision-id)
                                    (assoc :deleted true)))))
 
 (schema/defn ^:always-validate create-entry! :- (schema/maybe common/Entry)


### PR DESCRIPTION
First pass at versioning entries (aka posts). 

This change creates a new table `versions_entries` that will keep track of each version. A version is created on each entry change (create, edit, publish, and delete).  The contents of the entry is saved in the version table along with `:revision-id` `:version-uuid` `:revision-date` and `:revision-author`. `:revision-id` is also added to entry so that you know what the current version is.

The first version doesn't have an entry in the versions table, but does have a `:revision-id` equal to 0.

To test this you will need to be able to list all the items in the `entries` and `versions_entries` table.
I used http://localhost:8080/#dataexplorer to list the data.

Test steps:
- migrate your local DB
- create a post in the web ui as a draft
- from admin console or repl , list the new entry or all entries.
- [x] does the new post have a `:revision-id` of 0?
- [x] there should be no reference to this entry in `versions_entries`

- edit the same post
- from the admin console or repl list the entry
- [x] does the edited post have a `:revision-id` of 1?
- [x] is there an entry in the `versions_entries` table that has a `:revision-id` of 0 and all the old info from the previously edited post?

- publish the same post
- from the admin console or repl list the entry
- [x] does the published post have a `:revision-id` of 2?
- [x] is there an entry in the `versions_entries` table that has a `:revision-id` of 1?

- delete the post
- from the admin console or repl list the `versions_entries`
- [x] does the table have an entry with `:deleted true` and `:revision-id` of 2?
