### PR TITLE
SNS notification of NUX board selection.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 - oraclejdk8
 lein: 2.7.1
 addons:
-  rethinkdb: '2.3.5'
+  rethinkdb: '2.3.6'
 cache:
   directories:
   - "$HOME/.m2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 - oraclejdk8
 lein: 2.7.1
 addons:
-  rethinkdb: '2.3.6'
+  rethinkdb: '2.3.5'
 cache:
   directories:
   - "$HOME/.m2"

--- a/project.clj
+++ b/project.clj
@@ -14,9 +14,9 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.0-alpha7"]
+    [org.clojure/clojure "1.10.0-alpha8"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
-    [org.clojure/tools.cli "0.3.7"]
+    [org.clojure/tools.cli "0.4.0"]
     ;; Web application library https://github.com/ring-clojure/ring
     [ring/ring-devel "1.7.0"]
     ;; Web application library https://github.com/ring-clojure/ring

--- a/src/oc/storage/api/orgs.clj
+++ b/src/oc/storage/api/orgs.clj
@@ -162,6 +162,8 @@
                 (timbre/info "Samples sync - Creating board:" create-board-name "for org:" org-uuid)
                 (create-board conn updated-org {:name create-board-name} author))
                 create-board-names))]
+            (notification/send-trigger!
+              (notification/->trigger :nux updated-org {:nux-boards (vec desired-board-names)} author))
             (timbre/info "Syncing samples for:" org-uuid "complete.")))
 
       (timbre/info "Updated org:" slug)


### PR DESCRIPTION
Supports: https://github.com/belucid/open_company_activity_notifier/pull/1

Made the note optional in the notification (should have always been) since this new `:nux` notice doesn't have a note.

Testing:

This is on staging (for regression only). Can't NUX a user on staging and see this cause we don't run activity monitor there.

For the positive test you can get activity monitor running locally and NUX a user and see if it reports the sections selected. Or you can just look at #test-channel where I did the same.

Mainly looking for a regression here... so do some basic regression testing on the things that depend on storage SNS notifications and make sure none of them are broken:

- [x] search
- [x] change service
- [x] interaction service