### PR TITLE
People invite broken

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -207,6 +207,8 @@
 
   :eastwood {
     ;; Disable some linters that are enabled by default
+    ;; contant-test - just seems mostly ill-advised, logical constants are useful in something like a `->cond` 
+    ;; wrong-arity - unfortunate, but it's failing on 3/arity of sqs/send-message
     :exclude-linters [:constant-test :wrong-arity]
     ;; Enable some linters that are disabled by default
     :add-linters [:unused-namespaces :unused-private-vars] ; :unused-locals]

--- a/src/oc/storage/api/orgs.clj
+++ b/src/oc/storage/api/orgs.clj
@@ -74,13 +74,14 @@
   (let [drafts (default-entries-for "drafts")
         people-board-uuid (when (seq drafts)
                             (or (board-res/uuid-for conn (:slug org-result) "people")
-                                (board-res/create-board! (board-res/->board (:uuid org-result)
-                                                            {:name "People" :draft true}
-                                                            author))))]
+                                (board-res/create-board! conn (board-res/->board (:uuid org-result)
+                                                              {:name "People" :draft true :entries []}
+                                                              author))))]
     (doall (pmap #(let [headline (sub-name (:headline %) author)]
-                    (timbre/info "Creating draft entry:" headline "for user:" (:user-id author))
+                    (timbre/info "Creating draft entry:" headline "in:" people-board-uuid "for user:" (:user-id author))
                     (entry-res/create-entry! conn
-                      (entry-res/->entry conn people-board-uuid (assoc % :headline headline) author)))
+                      (entry-res/->entry conn people-board-uuid (assoc % :headline headline) author))
+                    (timbre/info "Created draft entry:" headline "in:" people-board-uuid "for user:" (:user-id author)))
               drafts))))
 
 (defn- create-entry


### PR DESCRIPTION
This fixes an issue creating drafts when inviting users w/o a People section.

To test:

- Sign up with a new org
- UNSELECT People as a "Topic that Matters"
- Delete your pre-existing draft
- [x] Now, invite a new user by email as a contributor, make sure you don't get any exceptions in storage (this tested invite w/o a People board existing)
-  Now, create a post in section "People" and publish it
- [x] Now, invite another new user by email as a contributor, make sure you don't get any exceptions in storage (this tested invite w/ a People board existing)
- Merge
- Deploy to beta
- Thank your lucky stars