### PR TITLE
Filter by board uuid to only return entries for the board created.

### DIFF
--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -42,7 +42,10 @@
   ([conn org :guard map? board :guard #(or (:draft %) (= (:slug %) (:slug board-res/default-drafts-board))) ctx]
   (let [org-slug (:slug org)
         slug (:slug board)
-        entries (entry-res/list-entries-by-org-author conn (:uuid org) (-> ctx :user :user-id) :draft {})
+        all-drafts (entry-res/list-entries-by-org-author conn (:uuid org) (-> ctx :user :user-id) :draft {})
+        entries (if (:draft board)
+                  (filterv #(= (:board-uuid %) (:uuid board)) all-drafts)
+                  all-drafts)
         board-uuids (distinct (map :board-uuid entries))
         boards (filter map? (map #(board-res/get-board conn %) board-uuids))
         board-map (zipmap (map :uuid boards) boards)


### PR DESCRIPTION
When creating a board we don't want to return all the drafts.  We only want to return the entries for the specified board.

To test:

- create a few drafts with existing boards
- open cmail
- add a new section with the section picker
- wait for the autosave
- [ ] does the auto save create a board and only return the entry created?

