### PR TITLE
Notify SNS of initial draft for users.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
     ;; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/clojure "1.10.0-alpha8"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
-    [org.clojure/tools.cli "0.4.0"]
+    [org.clojure/tools.cli "0.4.1"]
     ;; Web application library https://github.com/ring-clojure/ring
     [ring/ring-devel "1.7.0"]
     ;; Web application library https://github.com/ring-clojure/ring


### PR DESCRIPTION
No Trello card.

This addresses 1 of the 4 search cases that failed in today's testing. Namely the case of not finding the user's auto-created draft in search results.

To test:

- [x] Run this storage and your search service and Elastisearch
- [x] NUX a new org
- [x] Check in drafts that the user has their about them auto-draft post
- [x] Search for a word that's only in that post such as "favorite", is it found? Great
- [x] Merge
- [ ] Deploy
- [ ] Buy the world a coke