### PR TITLE
Ziggeo api error

### DIFF
--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -54,11 +54,13 @@
                 (or (nil? (:video-processed entry))
                     (nil? (:video-transcript entry))))
        (ziggeo/video (:video-id entry)
-         (fn [video]
-           (let [updated-entry (entry-res/update-video-data conn video entry)]
-             (when (and (some? ctx)
-                        (= (:status updated-entry) "published"))
-               (auto-share-on-publish conn ctx updated-entry))))))))
+         (fn [video error]
+           (if-not error
+             (let [updated-entry (entry-res/update-video-data conn video entry)]
+               (when (and (some? ctx)
+                          (= (:status updated-entry) "published"))
+                 (auto-share-on-publish conn ctx updated-entry)))
+             (entry-res/error-video-data conn entry)))))))
 
 ;; ----- Validations -----
 

--- a/src/oc/storage/resources/entry.clj
+++ b/src/oc/storage/resources/entry.clj
@@ -264,7 +264,7 @@
   (update-entry-no-user! conn
                          (:uuid entry)
                          (-> entry
-                             (assoc :video-processed nil)
+                             (assoc :video-processed false)
                              (assoc :video-transcript nil)
                              (assoc :video-error true))))
 

--- a/src/oc/storage/util/ziggeo.clj
+++ b/src/oc/storage/util/ziggeo.clj
@@ -39,6 +39,4 @@
         (cb (-> body
                 json/parse-string
                 keywordize-keys) error)
-        (cb {} (if-not error
-                 true
-                 error))))))
+        (cb {} true)))))

--- a/src/oc/storage/util/ziggeo.clj
+++ b/src/oc/storage/util/ziggeo.clj
@@ -35,7 +35,10 @@
   [token cb]
   (http/get (str ziggeo-api-url "/videos/" token) (auth-options auth)
     (fn [{:keys [status headers body error] :as resp}]
-      (when (and (> status 199) (< status 500))
+      (if (and (> status 199) (< status 500))
         (cb (-> body
                 json/parse-string
-                keywordize-keys))))))
+                keywordize-keys) error)
+        {} (if-not error
+             true
+             error)))))

--- a/src/oc/storage/util/ziggeo.clj
+++ b/src/oc/storage/util/ziggeo.clj
@@ -39,6 +39,6 @@
         (cb (-> body
                 json/parse-string
                 keywordize-keys) error)
-        {} (if-not error
-             true
-             error)))))
+        (cb {} (if-not error
+                 true
+                 error))))))


### PR DESCRIPTION
If an error is returned from the Ziggeo API call, mark the entry appropriately. 

This one is tough to test since we don't currently display any error conditions.  Also you have to manually code in the error from the API call to test. 

To test:

- make sure video works normally
- change the API call to `if` instead of `if-not` https://github.com/open-company/open-company-storage/blob/ziggeo-api-error/src/oc/storage/api/entries.clj#L58
- [x] check the database entry to see if `:video-error` is true, `:video-processed` is false and `:video-id` remains.