### PR TITLE
NUX video post and min/max sample entries

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
     [zprint "0.4.10"]
     
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.14"]
+    [open-company/lib "0.16.15"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - HTTP client/server http://www.http-kit.org/
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
@@ -82,7 +82,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.3-alpha1" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.3-alpha2" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]
@@ -90,7 +90,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.9"]
+        [jonase/eastwood "0.3.1"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]

--- a/resources/samples/all-hands.edn
+++ b/resources/samples/all-hands.edn
@@ -1,6 +1,7 @@
 [
   {
     :time-offset 1477 ; ~1 day ago
+    :board-slug "all-hands"
     :headline "[SAMPLE] All-hands, with follow-up details"
     :body "<p>Thanks again everyone for a great month! Cash on hand is <b>$3.1M</b> and the exec. team started weekly meetings to put together the strategy for next years financing. 💰 More to come soon.</p><p>We saw very positive results in one of our growth experiments, “Reward the user”, and no effect in our other experiment, “Email to Get Started”. The growth team is brainstorming how to double down on the positive results, and is discontinuing the “Email to get started” experiment.</p><p>On the product side, we’re moving towards a limited release of the admin dashboard to select customers next week. Let me know if you know of a customer that should be added to the list.</p><p><img src='https://cdn.filestackcontent.com/VTOajSpIRbCDiuIErSks' class='carrot-no-preview' data-media-type='image' data-thumbnail='https://cdn.filestackcontent.com/ZxEKWp3SHKB1c60RnCby' width='494' height='567'></p><p>Major support wins at Bradley Squared and CCNYC!</p><p>In Sales we received word that we are no longer being considered for the Florida deal, but we made the final cut for HIDTA and State Credit. Both deals should close this month.</p><p>Our <b>monthly recurring revenue is up 1.9%</b> for the month against our <b>goal of 3%</b>, but <b>churn spiked by 1.7%</b> 👎 compared to our <b>goal of down 1%</b>. Let’s focus on increasing touch in those first 60 days to expand feature use 🤞.</p>"
   }

--- a/resources/samples/decisions.edn
+++ b/resources/samples/decisions.edn
@@ -1,6 +1,7 @@
 [
   {
     :time-offset 9398 ; ~6 days ago
+    :board-slug "decisions"
     :headline "[SAMPLE] Discontinuing “Email to Get Started” Growth Experiment"
     :body "<p>The growth team decided to not put any further effort into the “Email to Get Started” growth experiment. <span class='medium-editor-mention-at oc-mention'
         data-first-name='Julie'

--- a/resources/samples/design.edn
+++ b/resources/samples/design.edn
@@ -1,6 +1,7 @@
 [
   {
     :time-offset 6534 ; ~4 days ago
+    :board-slug "design"
     :headline "[SAMPLE] Building design collaboration into our workflow with Abstract"
     :body "<p>Now that our designers are working in pairs, it’s more important than ever to be using a consistent set of elements as we scale our design system out to iOS 🍎 and Android 🤖. <br></p><p>With <a href='https://www.goabstract.com/' target='_blank' rel='noopener noreferrer'>Abstract</a>, now we can work collectively on a single file without worrying about which version is correct. We’re going to get some training setup next week but I assure you it’s incredibly straightforward. If you’re interested in signing up for training, let me know.</p>"
   }

--- a/resources/samples/general.edn
+++ b/resources/samples/general.edn
@@ -13,21 +13,36 @@
         data-found='true'>@Danielle</span> for finding Carrot, it’s been super easy to use and we think it’ll make a huge difference.</p>"
   }
   {
-    :time-offset 1477 ; ~1 day ago
+    :time-offset 11577 ; ~8 day ago
     :board-slug "general"
-    :headline "[SAMPLE] All-hands, with follow-up details"
-    :body "<p>Thanks again everyone for a great month! Cash on hand is <b>$3.1M</b> and the exec. team started weekly meetings to put together the strategy for next years financing. 💰 More to come soon.</p><p>We saw very positive results in one of our growth experiments, “Reward the user”, and no effect in our other experiment, “Email to Get Started”. The growth team is brainstorming how to double down on the positive results, and is discontinuing the “Email to get started” experiment.</p><p>On the product side, we’re moving towards a limited release of the admin dashboard to select customers next week. Let me know if you know of a customer that should be added to the list.</p><p><img src='https://cdn.filestackcontent.com/VTOajSpIRbCDiuIErSks' class='carrot-no-preview' data-media-type='image' data-thumbnail='https://cdn.filestackcontent.com/ZxEKWp3SHKB1c60RnCby' width='494' height='567'></p><p>Major support wins at Bradley Squared and CCNYC!</p><p>In Sales we received word that we are no longer being considered for the Florida deal, but we made the final cut for HIDTA and State Credit. Both deals should close this month.</p><p>Our <b>monthly recurring revenue is up 1.9%</b> for the month against our <b>goal of 3%</b>, but <b>churn spiked by 1.7%</b> 👎 compared to our <b>goal of down 1%</b>. Let’s focus on increasing touch in those first 60 days to expand feature use 🤞.</p>"
+    :headline "[SAMPLE] All-hands, pushing forward in Europe"
+    :body "<p>Another month in the books! Cash on hand is <b>$2.9M</b>.</p><p>After a great brainstorming session, the growth team is staring two new growth experiments, “Reward the user”, and “Email to Get Started”. <span class='medium-editor-mention-at oc-mention'
+        data-first-name='Adrian'
+        data-last-name='Tomei'
+        data-slack-username='Adrian'
+        data-user-id='9797-9797-9797'
+        data-email='adrian@sample.com'
+        data-avatar-url='https://cdn.filestackcontent.com/wXZpWBPHQwKvSy8R13gG'
+        data-found='true'>@Adrian</span> has all the details!</p><p>Here's a first look at the new admin dashboard. We'd like everyone to submit a list of customers that should get early access.</p><p><img src='https://cdn.filestackcontent.com/VTOajSpIRbCDiuIErSks' class='carrot-no-preview' data-media-type='image' data-thumbnail='https://cdn.filestackcontent.com/ZxEKWp3SHKB1c60RnCby' width='494' height='567'></p><p>Major support wins at <b>United Chem</b>! Great job.</p><div>No new sales announcements right now. We're bringing the EU online this month so expect our first European deals to close next quarter. Send EU questions to <span class='medium-editor-mention-at oc-mention'
+        data-first-name='Sam'
+        data-last-name='Darnell'
+        data-slack-username='Sam Darnell'
+        data-user-id='9797-9797-9797'
+        data-email='sam@sample.com'
+        data-avatar-url='https://cdn.filestackcontent.com/zUHZ3nSoRhiazQ2yLLTL'
+        data-found='true'>@Sam Darnell</span>.</div><div><p>Our <b>monthly recurring revenue is up 1.6%</b> for the month against our <b>goal of 3%</b>, and <b>churn is down by 0.7%</b>  compared to our <b>goal of down 1%</b>.</p></div>"
   }
   {
-    :time-offset 4431 ; ~3 days ago
+    :time-offset 4431 ; ~11 days ago
     :board-slug "general"
-    :headline "[SAMPLE] Annual planning and beyond"
-    :body "<p>Yesterday during out all hands call, I promised to share more information about our annual roadmap and today I’d like to share that plan with you! <br></p><p>Taking valuable lessons from the leadership summit, data from our research team, and input from product, I’ve broken our strategy into five principles. But before we get into that, I’d like to say thanks to a few people around the office for their help in getting this report together!</p>"
-    :attachments [{
-        :file-name "Product Strategy.pdf"
-        :file-size 18890
-        :file-type "application/pdf"
-        :file-url "https://cdn.filestackcontent.com/uAC2Y0UuR0iKLX3BK3hr"
-    }] 
+    :headline "[SAMPLE] Product annual planning... we need YOU!"
+    :body "<p>We're initiating our annual product planning and roadmap process. This will incorporate the valuable lessons from the leadership summit, data from our research team, and input from product. The <b>most important</b> input though comes from all of you! This won't work without all your help.</p><p>Please contact <span class='medium-editor-mention-at oc-mention'
+        data-first-name='Julie'
+        data-last-name='Johnson'
+        data-slack-username='Julie'
+        data-user-id='9797-9797-9797'
+        data-email='julie@sample.com'
+        data-avatar-url='https://cdn.filestackcontent.com/tJcQBrGOSOiMf8YowwtG'
+        data-found='true'>@Julie</span> as soon as you can with all your ideas.</p><p>I’ll share the plan with you in an all-hands and here in Carrot.</p>" 
   }
 ]

--- a/resources/samples/general.edn
+++ b/resources/samples/general.edn
@@ -1,7 +1,33 @@
 [
   {
     :time-offset 10 ; 10 minutes ago
-    :headline "[SAMPLE] Carrot keeps us aligned! 🚀"
-    :body "<p>It’s a struggle to keep everyone on the same page. Important information often gets missed or lost in fast moving conversations, and so everyone has a different idea of what’s important.</p><p>Carrot is a company digest that makes key information visible and easy to find, so everyone stays informed and aligned.</p>"
+    :board-slug "general"
+    :headline "[SAMPLE] Let’s use Carrot to stay aligned! 🚀"
+    :body "<p>In the team survey last week, you overwhelmingly said it’s getting harder to know what’s happening across the company. I hear you! Growing quickly has been awesome, but it’s also gotten super noisy.</p><p>We’re going to use Carrot to make sure leadership updates stay more visible. Here’s a quick video to show you how it works.</p><p><iframe class='carrot-no-preview' data-media-type='video' webkitallowfullscreen='true' mozallowfullscreen='true' allowfullscreen='true' data-thumbnail='https://img.youtube.com/vi/dMWpnHxQMP4/0.jpg' data-video-type='youtube' data-video-id='dMWpnHxQMP4' src='https://www.youtube.com/embed/dMWpnHxQMP4' width='560' height='315' frameborder='0'></iframe></p><p>It’ll also tie into Slack, so you can see and comment on posts from Slack. But now if you miss it, don’t worry. Carrot keeps everything organized so you can get caught up anytime.</p><p>So keep using Slack for back and forth chatter, and we’ll use Carrot for key announcements, updates, and decisions. Thanks to <span class='medium-editor-mention-at oc-mention'
+        data-first-name='Danielle'
+        data-last-name='Robertson'
+        data-slack-username='Danielle'
+        data-user-id='9797-9797-9797'
+        data-email='danielle@sample.com'
+        data-avatar-url='https://cdn.filestackcontent.com/4Xoz3CuzTgiVFdbWCSIw'
+        data-found='true'>@Danielle</span> for finding Carrot, it’s been super easy to use and we think it’ll make a huge difference.</p>"
+  }
+  {
+    :time-offset 1477 ; ~1 day ago
+    :board-slug "general"
+    :headline "[SAMPLE] All-hands, with follow-up details"
+    :body "<p>Thanks again everyone for a great month! Cash on hand is <b>$3.1M</b> and the exec. team started weekly meetings to put together the strategy for next years financing. 💰 More to come soon.</p><p>We saw very positive results in one of our growth experiments, “Reward the user”, and no effect in our other experiment, “Email to Get Started”. The growth team is brainstorming how to double down on the positive results, and is discontinuing the “Email to get started” experiment.</p><p>On the product side, we’re moving towards a limited release of the admin dashboard to select customers next week. Let me know if you know of a customer that should be added to the list.</p><p><img src='https://cdn.filestackcontent.com/VTOajSpIRbCDiuIErSks' class='carrot-no-preview' data-media-type='image' data-thumbnail='https://cdn.filestackcontent.com/ZxEKWp3SHKB1c60RnCby' width='494' height='567'></p><p>Major support wins at Bradley Squared and CCNYC!</p><p>In Sales we received word that we are no longer being considered for the Florida deal, but we made the final cut for HIDTA and State Credit. Both deals should close this month.</p><p>Our <b>monthly recurring revenue is up 1.9%</b> for the month against our <b>goal of 3%</b>, but <b>churn spiked by 1.7%</b> 👎 compared to our <b>goal of down 1%</b>. Let’s focus on increasing touch in those first 60 days to expand feature use 🤞.</p>"
+  }
+  {
+    :time-offset 4431 ; ~3 days ago
+    :board-slug "general"
+    :headline "[SAMPLE] Annual planning and beyond"
+    :body "<p>Yesterday during out all hands call, I promised to share more information about our annual roadmap and today I’d like to share that plan with you! <br></p><p>Taking valuable lessons from the leadership summit, data from our research team, and input from product, I’ve broken our strategy into five principles. But before we get into that, I’d like to say thanks to a few people around the office for their help in getting this report together!</p>"
+    :attachments [{
+        :file-name "Product Strategy.pdf"
+        :file-size 18890
+        :file-type "application/pdf"
+        :file-url "https://cdn.filestackcontent.com/uAC2Y0UuR0iKLX3BK3hr"
+    }] 
   }
 ]

--- a/resources/samples/lessons-learned.edn
+++ b/resources/samples/lessons-learned.edn
@@ -1,6 +1,7 @@
 [
   {
     :time-offset 7702 ; ~5 days ago
+    :board-slug "lessons-learned"
     :headline "[SAMPLE] Feature use as conversion and churn indicators"
     :body "<p><span class='medium-editor-mention-at oc-mention'
         data-first-name='Danielle'

--- a/resources/samples/marketing.edn
+++ b/resources/samples/marketing.edn
@@ -1,6 +1,7 @@
 [
   {
     :time-offset 14896 ; ~10 days ago
+    :board-slug "marketing"
     :headline "[SAMPLE] Customer journey emails (for launch and beyond)"
     :body "<p>I mapped out the customer journey emails needed to address customers from signup to expansion. This entire flow is obviously beyond us to execute on right away so I've described my recommended phases. Early adopters, as I'm sure you all know, are <i>incredibly</i> valuable at this stage. I'm hoping these sequences of emails will do enough to retain those who are a product fit.</p><div><ul><li>Phase 1: Early Access Waitlist</li><li>Phase 2: Customer onboarding</li><li>Phase 3: Re-engagement <i>(after launch)</i></li><li>Phase 4: Expansion <i>(future)</i></li></ul><div><img src='https://cdn.filestackcontent.com/7NllPIxjSlm4Fqa23UVT' class='carrot-no-preview' data-media-type='image' data-thumbnail='https://cdn.filestackcontent.com/LadCUf5QT7O1VG8xtc5M' width='522' height='355'><p>Please ping me with any questions on the design. <span class='medium-editor-mention-at oc-mention'
         data-first-name='Julie'

--- a/resources/samples/people.edn
+++ b/resources/samples/people.edn
@@ -1,6 +1,7 @@
 [
   {
     :time-offset 4002 ; ~2 days ago
+    :board-slug "people"
     :headline "[SAMPLE] New faces in new places!"
     :body "<p>Welcome to our new hires in the Product, Design and Engineering groups. I’m also particularly excited to announce that <span class='medium-editor-mention-at oc-mention'
         data-first-name='Adrian'

--- a/resources/samples/product-updates.edn
+++ b/resources/samples/product-updates.edn
@@ -1,6 +1,7 @@
 [
   {
     :time-offset 11792 ; ~8 days ago
+    :board-slug "product-updates"
     :headline "[Sample] Annual planning and beyond"
     :body "<p>Yesterday during out all hands call, I promised to share more information about our annual roadmap and today I’d like to share that plan with you! <br></p><p>Taking valuable lessons from the leadership summit, data from our research team, and input from product, I’ve broken our strategy into five principles. But before we get into that, I’d like to say thanks to a few people around the office for their help in getting this report together!</p>"
     :attachments [{

--- a/resources/samples/product-updates.edn
+++ b/resources/samples/product-updates.edn
@@ -3,7 +3,7 @@
     :time-offset 11792 ; ~8 days ago
     :board-slug "product-updates"
     :headline "[Sample] Annual planning and beyond"
-    :body "<p>Yesterday during out all hands call, I promised to share more information about our annual roadmap and today I’d like to share that plan with you! <br></p><p>Taking valuable lessons from the leadership summit, data from our research team, and input from product, I’ve broken our strategy into five principles. But before we get into that, I’d like to say thanks to a few people around the office for their help in getting this report together!</p>"
+    :body "<p>Yesterday during out all hands call, I promised to share more information about our annual roadmap and today I’d like to share that plan with you!</p><p>Taking valuable lessons from the leadership summit, data from our research team, and input from product, I’ve broken our strategy into five principles. But before we get into that, I’d like to say thanks to everyone for their input and help in getting this report together!</p>"
     :attachments [{
         :file-name "Product Strategy.pdf"
         :file-size 18890

--- a/resources/samples/week-in-review.edn
+++ b/resources/samples/week-in-review.edn
@@ -1,6 +1,7 @@
 [
   {
     :time-offset 4842 ; ~3 days ago
+    :board-slug "week-in-review"
     :headline "[SAMPLE] Admin dashboard beta FTW"
     :body "<p>We’ve concluded the Admin dashboard sprint, and the whole product team attended the Annual billing sprint kickoff with the usual reps from data, and sales. This sprint includes the secondary user story around non-admin billing contacts.</p><p>Kudos to <span class='medium-editor-mention-at oc-mention'
         data-first-name='Lane'

--- a/src/oc/storage/api/orgs.clj
+++ b/src/oc/storage/api/orgs.clj
@@ -170,7 +170,7 @@
                 (create-board conn updated-org {:name create-board-name} author))
                 create-board-names))
               ;; create a min of 3 / max of 4 sample entries, including at least 1 from the forced board
-              selected-entries (take 3 (flatten (map #(default-entries-for %) selected-board-names)))
+              selected-entries (take 3 (flatten (map default-entries-for selected-board-names)))
               forced-entries (default-entries-for config/forced-board-name)
               total-entries (take 4 (concat selected-entries forced-entries))
               create-entries (map #(assoc % :author (lib-schema/author-for-user author))

--- a/src/oc/storage/api/orgs.clj
+++ b/src/oc/storage/api/orgs.clj
@@ -170,7 +170,8 @@
                 (create-board conn updated-org {:name create-board-name} author))
                 create-board-names))
               ;; create a min of 3 / max of 4 sample entries, including at least 1 from the forced board
-              selected-entries (take 3 (flatten (map default-entries-for selected-board-names)))
+              selected-entries (take 3 (flatten (map default-entries-for
+                                                  (remove #(= % config/forced-board-name) selected-board-names))))
               forced-entries (default-entries-for config/forced-board-name)
               total-entries (take 4 (concat selected-entries forced-entries))
               create-entries (map #(assoc % :author (lib-schema/author-for-user author))

--- a/src/oc/storage/api/orgs.clj
+++ b/src/oc/storage/api/orgs.clj
@@ -92,34 +92,33 @@
 
 (defn- create-entry
   "Create any default entries (from config) for a new default board."
-  [conn org board entry user]
-  (timbre/info "Creating sample entry:" (:headline entry) "for board:" (:uuid board))
-  (let [ts (f/unparse lib-time/timestamp-format (t/minus (t/now) (t/minutes (or (:time-offset entry) 0))))
-        entry-res (db-common/create-resource conn common-res/entry-table-name 
-                    (-> (entry-res/->entry conn (:uuid board)
-                                                (dissoc entry :author :time-offset :comments :reactions)
-                                                (:author entry))
-                      (assoc :sample true)
-                      (assoc :status :published)
-                      (assoc :created-at ts)
-                      (assoc :updated-at ts)
-                      (assoc :published-at ts)
-                      (assoc :publisher (:author entry))) ts)
-        interaction-resource (merge entry entry-res)]
-    ;; notify of new entry
-    (notification/send-trigger! (notification/->trigger :add org board {:new entry-res} user nil))  
-    ;; create any entry interactions (comments and/or reactions) in parallel
-    (doall (pmap #(create-interaction conn (:org-uuid board) % interaction-resource)
-              (concat (:comments interaction-resource) (:reactions interaction-resource))))))
+  [conn org entry user]
+  (timbre/info "Creating sample entry:" (:headline entry) "for board:" (:board-slug entry))
+)
+  ; (let [ts (f/unparse lib-time/timestamp-format (t/minus (t/now) (t/minutes (or (:time-offset entry) 0))))
+  ;       board (board-res/get-board conn (:uuid org) (:board-slug entry))
+  ;       entry-res (db-common/create-resource conn common-res/entry-table-name 
+  ;                   (-> (entry-res/->entry conn (:uuid board)
+  ;                                               (dissoc entry :board-slug :author :time-offset :comments :reactions)
+  ;                                               (:author entry))
+  ;                     (assoc :sample true)
+  ;                     (assoc :status :published)
+  ;                     (assoc :created-at ts)
+  ;                     (assoc :updated-at ts)
+  ;                     (assoc :published-at ts)
+  ;                     (assoc :publisher (:author entry))) ts)
+  ;       interaction-resource (merge entry entry-res)]
+  ;   ;; notify of new entry
+  ;   (notification/send-trigger! (notification/->trigger :add org board {:new entry-res} user nil))  
+  ;   ;; create any entry interactions (comments and/or reactions) in parallel
+  ;   (doall (pmap #(create-interaction conn (:org-uuid board) % interaction-resource)
+  ;             (concat (:comments interaction-resource) (:reactions interaction-resource))))))
 
 (defn- create-board
-  "Create any default boards (from config) and their contents for a new org."
+  "Create a boards for a new org."
   [conn org board author]
-  (let [board-slug (slugify/slugify (:name board))
-        entries (map #(assoc % :author (lib-schema/author-for-user author)) (default-entries-for board-slug))
-        board-result (board-res/create-board! conn (board-res/->board (:uuid org) (assoc board :entries []) author))]
-    (doall (pmap #(create-entry conn org board-result % author) entries)))) ; create any board entries in parallel
-
+  (board-res/create-board! conn (board-res/->board (:uuid org) (assoc board :entries []) author)))
+ 
 ;; ----- Actions -----
 
 (defn create-org [conn ctx]
@@ -127,18 +126,18 @@
   (if-let* [new-org (:new-org ctx)
             org-result (org-res/create-org! conn new-org)] ; Add the org
 
-    ;; Org creation succeeded, so create the default boards
+    ;; Org creation succeeded, so create the default boards and drafts
     (let [uuid (:uuid org-result)
           author (:user ctx)]
       (timbre/info "Created org:" uuid)
-      (timbre/info "Creating default boards for org:" uuid)
       (notification/send-trigger! (notification/->trigger :add {:new org-result} (:user ctx)))
-      (doseq [board (map #(hash-map :name %) config/new-org-board-names)]
-        (create-board conn org-result board author))
       (timbre/info "Creating initial drafts for user:" (:user-id author) "of org:" uuid)
       (create-drafts conn org-result author)
+      (timbre/info "Creating default boards for org:" uuid)
+      (doseq [board (map #(hash-map :name %) config/new-org-board-names)]
+        (create-board conn org-result board author))
       {:created-org org-result})
-  
+      
     (do (timbre/error "Failed creating org.") false)))
 
 (defn- update-org [conn ctx slug]
@@ -151,24 +150,31 @@
       (when (:samples ctx) ; are we PATCH'ing boards from NUX?
         ;; Sync the boards the org has w/ the boards PATCH'd from the NUX by creating and deleting boards
         (timbre/info "Syncing samples for:" org-uuid)
-        (let [existing-boards (board-res/list-boards-by-org conn org-uuid)
+        (let [selected-board-names (vec (:boards ctx))
+              existing-boards (board-res/list-boards-by-org conn org-uuid)
               existing-board-names (set (map :name existing-boards))
               existing-boards-by-name (zipmap (map :name existing-boards) existing-boards)
-              desired-board-names (set (conj (:boards ctx) config/forced-board-name))
+              desired-board-names (set (conj selected-board-names config/forced-board-name))
               delete-board-names (clojure.set/difference existing-board-names desired-board-names)
               create-board-names (clojure.set/difference desired-board-names existing-board-names)
               ;; including these next 2 in the let to prevent Eastwood from having a tizzy about the doall
               _deleted-boards (doall (pmap (fn [delete-board-name]
-                (timbre/info "Samples sync - Deleting board:" delete-board-name "for org:" org-uuid)
+                (timbre/info "NUX sync - Deleting board:" delete-board-name "for org:" org-uuid)
                 (let [board (board-res/get-board conn (:uuid (get existing-boards-by-name delete-board-name)))
                       entries (entry-res/list-all-entries-by-board conn (:uuid board))]
                   (board-res/delete-board! conn org-uuid (:slug board) entries)
                   (notification/send-trigger! (notification/->trigger :delete update-result {:old board} (:user ctx)))))
                 delete-board-names))
               _created-boards (doall (pmap (fn [create-board-name]
-                (timbre/info "Samples sync - Creating board:" create-board-name "for org:" org-uuid)
+                (timbre/info "NUX sync - Creating board:" create-board-name "for org:" org-uuid)
                 (create-board conn updated-org {:name create-board-name} author))
-                create-board-names))]
+                create-board-names))
+              ;; min 3 / max 4 sample entries
+              selected-entries (take 3 (flatten (map #(default-entries-for %) selected-board-names)))
+              forced-entries (default-entries-for config/forced-board-name)
+              create-entries (map #(assoc % :author (lib-schema/author-for-user author))
+                              (take 4 (into selected-entries forced-entries)))
+              _created-entries (doall (pmap #(create-entry conn org % author) create-entries))]            
             (notification/send-trigger!
               (notification/->trigger :nux updated-org {:nux-boards (vec desired-board-names)} author))
             (timbre/info "Syncing samples for:" org-uuid "complete.")))

--- a/src/oc/storage/async/bot.clj
+++ b/src/oc/storage/async/bot.clj
@@ -23,7 +23,6 @@
 (def ShareEntryTrigger 
   "A Slack bot trigger to share an Entry."
   (merge BotTrigger {
-    :type (schema/enum "share-entry")  
     :note (schema/maybe schema/Str)
     :org-slug lib-schema/NonBlankStr
     :org-name (schema/maybe schema/Str)

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -102,10 +102,9 @@
   "Week in review"})
 
 (defonce new-org-board-names #{
-  "General"
   "All-hands"
   "Decisions"
-  "Lessons Learned"
+  "Lessons learned"
   "People"
   "Week in review"})
 


### PR DESCRIPTION
https://trello.com/c/o1nxc6hg

This PR:

- swaps out the main "General" samples for one with the Carrot video embedded in it
- adds 2 additional "General" section samples if needed
- ensures there are a minimum of 3 sample entries w/ every NUX
- ensures there are a maximum of 4 sample entries w/ every NUX

- [x] Review the code

To test, go through NUX 3 times...

Minimal:

- NUX a new org, and when selecting topics, deselect EVERY topic
- [x] 3 sample posts created, all in "General"?
- [x] Most recent sample post is "Let’s use Carrot to stay aligned! 🚀" w/ our Youtube video?

Usual path:

- NUX a new org, and when selecting topics, don't do anything, leave the defaults as-is
- [x] 4 sample posts created, just one "General"?
- [x] Most recent sample post is "Let’s use Carrot to stay aligned! 🚀" w/ our Youtube video?

Maximal:

- NUX a new org, and when selecting topics, select EVERY topic
- [x] 4 sample posts created, just one "General"?
- [x] Most recent sample post is "Let’s use Carrot to stay aligned! 🚀" w/ our Youtube video?

- [x] Merge
- [ ] Deploy
- [ ] Enjoy the sweet, sweet sunshine