### PR TITLE
Fix sample posts retrieve.

### DIFF
--- a/src/oc/storage/api/orgs.clj
+++ b/src/oc/storage/api/orgs.clj
@@ -45,10 +45,11 @@
 
 (defn- default-entries-for
   "Return any sample posts for a specific board slug."
-  [board-slug]
+  [board-name]
   (try
-    (->
-      (str "samples/" board-slug ".edn")
+    (->> board-name
+      (slugify/slugify)
+      (format "samples/%s.edn")
       (clojure.java.io/resource)
       (slurp)
       (read-string))


### PR DESCRIPTION
BUG: sample posts are not created right now on staging but they are locally. Problem is that we are passing board names to `oc.storage.api.orgs/default-entries-for` function instead of slugs.
Since MacOS is not case sensitive for filenames it works locally when the section name is equal to the slug (ie no spaces but dash like All-hands, for Team and Hiring it won't work).
On staging no sample posts are created since it's also case sensitive.

NB: tests needs to be run on staging

To test:
- deploy mainline to staging
- create a new org
- select ONLY the following sections: Product updates and Week in review
- [x] you should get 0 sample posts after picking the sections
- deploy this branch to staging
- create a new org
- select ONLY the following sections: Product updates and Week in review
- [x] you should get 4 sample posts: 2 general, 1 for Product updates and 1 for week in review
- [x] make sure the first sample posts it titled "[SAMPLE] Let’s use Carrot to stay aligned! 🚀" and has a youtube video in the body