### PR TITLE
Allow us to easily use the REPL for DB access only

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -184,7 +184,7 @@
   :repl-options {
     :welcome (println (str "\n" (slurp (clojure.java.io/resource "ascii_art.txt")) "\n"
                       "OpenCompany Storage REPL\n"
-                      "\nReady to do your bidding... I suggest (go) or (go <port>) as your first command.\n"))
+                      "\nReady to do your bidding... I suggest (go) or (go <port>) or (go-db) as your first command.\n"))
     :init-ns dev
   }
 

--- a/src/dev.clj
+++ b/src/dev.clj
@@ -22,6 +22,9 @@
                                             :sqs-creds {:access-key c/aws-access-key-id
                                                         :secret-key c/aws-secret-access-key}})))))
 
+(defn init-db []
+  (alter-var-root #'system (constantly (components/db-only-auth-system {}))))
+
 (defn bind-conn! []
   (alter-var-root #'conn (constantly (pool/claim (get-in system [:db-pool :pool])))))
 
@@ -31,6 +34,13 @@
 (defn stop []
   (alter-var-root #'system (fn [s] (when s (component/stop s))))
   (println (str "\nWhen you're ready to start the system again, just type: (go)\n")))
+
+(defn go-db []
+  (init-db)
+  (start⬆)
+  (bind-conn!)
+  (println (str "A DB connection is available with: conn\n"
+                "When you're ready to stop the system, just type: (stop)\n")))
 
 (defn go
   

--- a/src/oc/storage/components.clj
+++ b/src/oc/storage/components.clj
@@ -91,6 +91,10 @@
         (dissoc component :auth-notification))
       component)))
 
+(defn db-only-auth-system [_opts]
+  (component/system-map
+   :db-pool (map->RethinkPool {:size c/db-pool-size :regenerate-interval 5})))
+
 (defn storage-system [{:keys [host port handler-fn sqs-creds sqs-queue auth-sqs-msg-handler] :as opts}]
   (component/system-map
     :db-pool (map->RethinkPool {:size c/db-pool-size :regenerate-interval 5})


### PR DESCRIPTION
No trello card.

Sometimes we need to be able to run the REPL for only DB access w/o running all the other components in the service. This PR makes it easy with `(go-db)`.

To test:

- Launch a REPL
- Run `(go-db)`
- Access DB with `(team/list-teams conn)`
- [x] All good?
- Stop with `(stop)`
- [x] All good?
- Regression test with `(go)`
- Stop with `(stop)`
- [x] All good?
- Merge