### PR TITLE
Truncate org slug

### DIFF
--- a/src/oc/storage/resources/org.clj
+++ b/src/oc/storage/resources/org.clj
@@ -38,6 +38,12 @@
   [org]
   (apply dissoc org ignored-properties))
 
+(defn trunc
+  "
+  Truncate a string based on length
+  "
+  [s n]
+  (subs s 0 (min (count s) n)))
 ;; ----- Organization Slug -----
 
 ;; Excluded slugs due to existing and potential URL routing conflicts
@@ -83,7 +89,7 @@
     (-> org-props
         keywordize-keys
         clean
-        (assoc :slug slug)
+        (assoc :slug (trunc slug 126)) ;; primary key length is 127
         (assoc :uuid (db-common/unique-id))
         (assoc :authors [(:user-id user)])
         (update :promoted #(or % default-promoted))


### PR DESCRIPTION
Ensure that the org slug doesn't go over the 127 rethinkdb, char limit for primary keys.

To test

- sign up and when you create an org use a really long name (over 127 chars)
- [x] is the org created with a truncated name? 