### PR TITLE
Adjust default and available NUX boards.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.0-alpha8"]
+    [org.clojure/clojure "1.10.0-RC1"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.4.1"]
     ;; Web application library https://github.com/ring-clojure/ring
@@ -39,7 +39,7 @@
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     [zprint "0.4.10"]
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.16alpha0"]
+    [open-company/lib "0.16.16"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - HTTP client/server http://www.http-kit.org/
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
@@ -81,7 +81,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.3-alpha2" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.4" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -93,19 +93,19 @@
   "Kudos"
   "Lessons learned"
   "Marketing"
+  "OKRs"
   "People"
   "Playbooks"
-  "Press"
   "Product updates"
   "Sales"
   "Team and hiring"
   "Week in review"})
 
 (defonce new-org-board-names #{
-  "All-hands"
   "Decisions"
   "Lessons learned"
   "People"
+  "Product Updates"
   "Week in review"})
 
 (defonce forced-board-name "General")


### PR DESCRIPTION
https://trello.com/c/i6ysX5UJ

This merely adjust the sections in NUX.

To test:

-  NUX a new org.
- [x] "All-hands" is NOT selected by default
- [x] "Product updates" IS selected by default
- [x] During NUX you don't see "Press" as a section
- [x] During NUX you do see "OKRs" as a section
- Merge
- Deploy
- Repeat
