### PR TITLE
No version update when sharing a post

### DIFF
--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -124,7 +124,7 @@
             user (:user ctx)
             share-requests (:share-requests ctx)
             shared {:shared (concat (or (:shared entry) []) share-requests)}
-            update-result (entry-res/update-entry! conn (:uuid entry) shared user)
+            update-result (entry-res/update-entry-no-version! conn (:uuid entry) shared user)
             entry-with-comments (assoc entry :existing-comments (entry-res/list-comments-for-entry conn (:uuid entry)))]
     (do
       (when (and (seq? share-requests) (any? share-requests))

--- a/src/oc/storage/resources/entry.clj
+++ b/src/oc/storage/resources/entry.clj
@@ -223,7 +223,7 @@
   [original-entry entry user]
   (let [authors (:author original-entry)
         ts (db-common/current-timestamp)
-        updated-authors (into [] (concat authors [(assoc (lib-schema/author-for-user user) :updated-at ts)]))]
+        updated-authors (concat authors [(assoc (lib-schema/author-for-user user) :updated-at ts)])]
     (assoc entry :author updated-authors)))
 
 (schema/defn ^:always-validate update-entry-no-version! :- (schema/maybe common/Entry)


### PR DESCRIPTION
We skip the creation of a new post version when sharing a post.

Right now we get an error if we share the same post more than once. The error is from rethinkdb (duplicate primary key). 
https://sentry.io/opencompany/oc-beta-storage/issues/742781328/?referrer=slack

This will be difficult to test once we fix the rage click on the share button.

To test for now:

- share a post 
- [x] does clicking the share button not generate the duplicate key error?
- [x] verify that the version number isn't incremented
- [x] verify that a new version wasn't saved in the `versions_entries` table

