### PR TITLE
Fix duplicated share [WIP]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     [zprint "0.4.10"]
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.20alpha"]
+    [open-company/lib "0.16.20alpha1"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - HTTP client/server http://www.http-kit.org/
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     [zprint "0.4.10"]
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.20alpha1"]
+    [open-company/lib "0.16.21alpha"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - HTTP client/server http://www.http-kit.org/
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     [zprint "0.4.10"]
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.21alpha"]
+    [open-company/lib "0.16.21"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - HTTP client/server http://www.http-kit.org/
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     [zprint "0.4.10"]
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.19"]
+    [open-company/lib "0.16.20alpha"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - HTTP client/server http://www.http-kit.org/
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun

--- a/src/oc/storage/api/activity.clj
+++ b/src/oc/storage/api/activity.clj
@@ -119,7 +119,7 @@
   ;; Existentialism
   :exists? (fn [ctx] (if-let* [_slug? (slugify/valid-slug? slug)
                                org (or (:existing-org ctx) (org-res/get-org conn slug))]
-                        {:existing-org org}
+                        {:existing-org (api-common/rep org)}
                         false))
 
   ;; Responses

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -53,7 +53,7 @@
                             [] []
                             (:access-level ctx) (-> ctx :user :user-id))
                         entries)]
-    (assemble-board org-slug board entry-reps ctx)))
+    (api-common/rep (assemble-board org-slug board entry-reps ctx))))
 
   ;; Regular board
   ([conn org :guard map? board :guard map? ctx]
@@ -98,9 +98,9 @@
             board-data (-> board-map
                         (dissoc :private-notifications :note :pre-flight :exclude)
                         (assoc :entries entry-data))]
-        {:new-board (board-res/->board (:uuid org) board-data author)
-         :existing-org org
-         :notifications notifications})
+        {:new-board (api-common/rep (board-res/->board (:uuid org) board-data author))
+         :existing-org (api-common/rep org)
+         :notifications (api-common/rep notifications)})
 
       (catch clojure.lang.ExceptionInfo e
         [false, {:reason (.getMessage e)}])) ; Not a valid new board
@@ -112,11 +112,11 @@
             board-data (dissoc board-props :private-notifications :note)]
     (let [updated-board (merge board (board-res/clean board-data))]
       (if (lib-schema/valid? common-res/Board updated-board)
-        {:existing-org org
-         :existing-board board
-         :board-update updated-board
-         :notifications (:private-notifications board-props)}
-        [false, {:board-update updated-board}])) ; invalid update
+        {:existing-org (api-common/rep org)
+         :existing-board (api-common/rep board)
+         :board-update (api-common/rep updated-board)
+         :notifications (api-common/rep (:private-notifications board-props))}
+        [false, {:board-update (api-common/rep updated-board)}])) ; invalid update
     true)) ; No org or board, so this will fail existence check later
 
 ;; ----- Actions -----
@@ -131,7 +131,7 @@
             updated-board (member-fn conn (-> ctx :existing-org :uuid) slug user-id)]
     (do
       (timbre/info "Added" (str (name member-type) ":") user-id "to board:" slug "of org:" org-slug)
-      {:updated-board updated-board})
+      {:updated-board (api-common/rep updated-board)})
     
     (do
       (timbre/error "Failed adding" (str (name member-type) ":") user-id "to board:" slug "of org:" org-slug)
@@ -147,7 +147,7 @@
             updated-board (member-fn conn (-> ctx :existing-org :uuid) slug user-id)]
     (do
       (timbre/info "Removed" (str (name member-type) ":") user-id "to board:" slug "of org:" org-slug)
-      {:updated-board updated-board})
+      {:updated-board (api-common/rep updated-board)})
     
     (do
       (timbre/error "Failed removing" (str (name member-type) ":") user-id "to board:" slug "of org:" org-slug)
@@ -237,7 +237,7 @@
             (remove-member conn ctx (:slug org) (:slug updated-result) :viewers viewer))))
       (let [final-result (board-res/get-board conn (:uuid updated-result))]
         (notification/send-trigger! (notification/->trigger :update org {:old board :new final-result :notifications notifications} user invitation-note))
-        {:updated-board final-result}))
+        {:updated-board (api-common/rep final-result)}))
 
     (do (timbre/error "Failed updating board:" slug "of org:" org-slug) false)))
 
@@ -299,7 +299,7 @@
                                             (board-res/drafts-board org-uuid (:user ctx))
                                             ;; Regular board by slug
                                             (board-res/get-board conn org-uuid slug)))]
-                        {:existing-org org :existing-board board}
+                        {:existing-org (api-common/rep org) :existing-board (api-common/rep board)}
                         false))
 
   ;; Actions
@@ -403,13 +403,13 @@
                               user-id (:data ctx)
                               org (and (slugify/valid-slug? org-slug) (org-res/get-org conn org-slug))
                               board (and (slugify/valid-slug? slug) (board-res/get-board conn (:uuid org) slug))]
-                        {:existing-org org :existing-board board 
+                        {:existing-org (api-common/rep org) :existing-board (api-common/rep board)
                          :existing? ((set (member-type board)) user-id)}
                         false))
     :delete (fn [ctx] (if-let* [org (and (slugify/valid-slug? org-slug) (org-res/get-org conn org-slug))
                                 board (and (slugify/valid-slug? slug) (board-res/get-board conn (:uuid org) slug))
                                 exists? ((set (member-type board)) user-id)] ; short circuits the delete w/ a 404
-                        {:existing-org org :existing-board board :existing? true}
+                        {:existing-org (api-common/rep org) :existing-board (api-common/rep board) :existing? true}
                         false))}) ; org or author doesn't exist
 
   ;; Actions

--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -123,7 +123,7 @@
             entry (:existing-entry ctx)
             user (:user ctx)
             share-requests (:share-requests ctx)
-            shared {:shared (concat (or (:shared entry) []) share-requests)}
+            shared {:shared (take 50 (sort-by :shared-at (concat (or (:shared entry) []) share-requests)))}
             update-result (entry-res/update-entry-no-version! conn (:uuid entry) shared user)
             entry-with-comments (assoc entry :existing-comments (entry-res/list-comments-for-entry conn (:uuid entry)))]
     (do

--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -109,7 +109,7 @@
             _seq? (seq? share-props)
             share-requests (map #(assoc % :shared-at ts) share-props)]
     (if (every? #(lib-schema/valid? common-res/ShareRequest %) share-requests)
-        {:existing-entry existing-entry :share-requests share-requests}
+        {:share-requests share-requests}
         [false, {:share-requests share-requests}]) ; invalid share request
     
     true)) ; no existing entry, so this will fail existence check later


### PR DESCRIPTION
### Related PR: https://github.com/open-company/open-company-lib/pull/39

Proposed solution for the duplicated `:shared` key, the problem is that Liberator apply a deep merge/concat function on the keys of the context between handlers.

The solutions i have thought are 2:
1) avoid reusing the same key
2) use a meta key `:replace` on the data to make sure Liberator replace them

The former can be tricky and can lead to bugs if you forget or with new devs, so i went for the latter, here is the solution i propose.

If you like it we should apply the same set of changes to auth (i don't think we have other services that writes to RethinkDB).

To discuss: how much do you think would be a good limit for `:author` and what data should we keep? For example should we keep only the last x authors or the last x not equal authors (compact continuous edits from the same author into one)?

To test:
- add a new entry
- share one time
- share another time
- [x] do you see only 2 shares? Good
- now with an entry that has some shares, share it again to get to 20 shares
- [x] can you NOT exceed the 20 share limit? Good
- do a general app check to make sure this doesn't break old code
- [x] signup
- [x] setup sections
- [x] add draft
- [x] edit draft
- [x] publish draft
- [x] move entry from board to board
- [x] update the org data
- [x] add a section
- [x] add a private section
- [x] ...any other you can think of