### PR TITLE
Fix shared limit

### DIFF
--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -123,7 +123,7 @@
             entry (:existing-entry ctx)
             user (:user ctx)
             share-requests (:share-requests ctx)
-            shared {:shared (take 50 (sort-by :shared-at (concat (or (:shared entry) []) share-requests)))}
+            shared {:shared (take 50 (reverse (sort-by :shared-at (concat (or (:shared entry) []) share-requests))))}
             update-result (entry-res/update-entry-no-version! conn (:uuid entry) shared user)
             entry-with-comments (assoc entry :existing-comments (entry-res/list-comments-for-entry conn (:uuid entry)))]
     (do


### PR DESCRIPTION
Reverse the order of the shared list to keep the most recent ones.

To test:
- take an entry with 50 shares
- add another
- [x] make sure the list of shares contains the last share (check the :shared-at value)