### PR TITLE
Cut shared lists

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -162,6 +162,7 @@
                  '[oc.storage.resources.reaction :as reaction]
                  '[oc.storage.representations.board :as board-rep]
                  '[oc.storage.representations.entry :as entry-rep]
+                 '[oc.storage.resources.maintenance :as maint]
                  )
       ]
     }]

--- a/src/oc/storage/resources/maintenance.clj
+++ b/src/oc/storage/resources/maintenance.clj
@@ -9,8 +9,8 @@
 
 (defn- update-entry [conn entry original-entry dry-run]
   (schema/validate common/Entry entry)
-  (timbre/info "--> Updating entry from" (count (:shared original-entry)) "to" (count (:shared entry)))
   (when-not dry-run
+    (timbre/info "--> Updating entry from" (count (:shared original-entry)) "to" (count (:shared entry)))
     (db-common/update-resource conn common/entry-table-name :uuid original-entry entry (db-common/current-timestamp))))
 
 (schema/defn ^:always-validate shared-dedup-and-limit-for-entry!

--- a/src/oc/storage/resources/maintenance.clj
+++ b/src/oc/storage/resources/maintenance.clj
@@ -1,0 +1,58 @@
+(ns oc.storage.resources.maintenance
+  "fns to maintain storage resources."
+  (:require [schema.core :as schema]
+            [taoensso.timbre :as timbre]
+            [clojure.pprint :as pp]
+            [oc.lib.db.common :as db-common]
+            [oc.lib.schema :as lib-schema]
+            [oc.storage.resources.org :as org-res]
+            [oc.storage.resources.common :as common]))
+
+(defn- update-entry [conn entry original-entry]
+  (schema/validate common/Entry entry)
+  (timbre/info "--> Updating entry from" (count (:shared original-entry)) "to" (count (:shared entry)))
+  (db-common/update-resource conn common/entry-table-name :uuid original-entry entry (db-common/current-timestamp)))
+
+(schema/defn ^:always-validate shared-limit-for-entry!
+  "Given a RethinkDB connection, an entry map and a limit to apply to share cut the list of
+   shared to the passed value keeping only the newest"
+  [conn :- lib-schema/Conn entry :- common/Entry limit]
+  (let [old-shared (:shared entry)
+        grouped-shared (group-by :shared-at old-shared)
+        unique-shared (into [] (map first (vals grouped-shared)))
+        sorted-shared (reverse (sort-by :shared-at unique-shared))
+        limited-shared (take limit sorted-shared)]
+    (timbre/info "      Old shared" (count old-shared))
+    (timbre/info "      Unique shared" (count unique-shared))
+    (timbre/info "      Limited shared" (count limited-shared))
+    (update-entry conn (assoc entry :shared limited-shared) entry)
+    (timbre/info "      Cut!")))
+
+(schema/defn ^:always-validate list-all-entries-by-org!
+  [conn :- lib-schema/Conn org-uuid :- lib-schema/UniqueID]
+  (db-common/read-resources conn common/entry-table-name :status-org-uuid [[:published org-uuid]]))
+
+(schema/defn ^:always-validate shared-limit-for-org!
+  "Give a RethinkDB connection and an org-uuid, load all the published entries of the org
+   and call the shared-limit-for-entry on all that are exceeding the shared limit."
+  [conn :- lib-schema/Conn org-uuid :- lib-schema/UniqueID limit]
+  (timbre/info "  Cut for org" org-uuid)
+  (let [entries (list-all-entries-by-org! conn org-uuid)]
+    (timbre/info "  Entries count:" (count entries))
+    (for [entry entries]
+      (do
+        (timbre/info "    Checking entry" (:uuid entry) "shared:" (count (:shared entry)))
+        (when (> (count (:shared entry)) limit)
+          (shared-limit-for-entry! conn entry limit))))))
+
+(defn shared-limit!
+  "List all the present orgs, for each load all the entries that have more then 20 shared entries
+   and cut them to the 20 more recent values."
+  [conn batch-length batch-offset & [limit]]
+  (let [limit (or limit 50)]
+    (timbre/info "Cut :shared lists for all entries to:" limit "(orgs from " (* batch-length batch-offset) "to" (* batch-length (inc batch-offset)) ")")
+    (let [orgs (org-res/list-orgs conn)
+          batches (into [] (partition batch-length orgs))
+          batch (into [] (get batches batch-offset))]
+      (for [org batch]
+        (shared-limit-for-org! conn (:uuid org) limit)))))

--- a/src/oc/storage/resources/maintenance.clj
+++ b/src/oc/storage/resources/maintenance.clj
@@ -45,8 +45,9 @@
           (shared-limit-for-entry! conn entry limit dry-run))))))
 
 (defn shared-limit!
-  "List all the present orgs, for each load all the entries that have more then 20 shared entries
-   and cut them to the 20 more recent values."
+  "Given a batch size and offset load the orgs of that batch and run the shared limit,
+  use :dry-run option to see the eventual output, to actually update you need to specify
+  :dry-run false."
   [conn {:keys [batch-length batch-offset limit dry-run]}]
   (let [batch-length (or batch-length 20)
         batch-offset (or batch-offset 0)

--- a/src/oc/storage/resources/maintenance.clj
+++ b/src/oc/storage/resources/maintenance.clj
@@ -41,7 +41,7 @@
     (for [entry entries]
       (do
         (timbre/info "    Checking entry" (:uuid entry) "shared:" (count (:shared entry)))
-        (when (pos? (count (:shared entry)))
+        (when (> (count (:shared entry)) 1)
           (shared-dedup-and-limit-for-entry! conn entry limit dry-run))))))
 
 (defn shared-limit!

--- a/src/oc/storage/resources/maintenance.clj
+++ b/src/oc/storage/resources/maintenance.clj
@@ -13,7 +13,7 @@
   (when-not dry-run
     (db-common/update-resource conn common/entry-table-name :uuid original-entry entry (db-common/current-timestamp))))
 
-(schema/defn ^:always-validate shared-limit-for-entry!
+(schema/defn ^:always-validate shared-dedup-and-limit-for-entry!
   "Given a RethinkDB connection, an entry map and a limit to apply to share cut the list of
    shared to the passed value keeping only the newest"
   [conn :- lib-schema/Conn entry :- common/Entry limit dry-run]
@@ -41,8 +41,8 @@
     (for [entry entries]
       (do
         (timbre/info "    Checking entry" (:uuid entry) "shared:" (count (:shared entry)))
-        (when (> (count (:shared entry)) limit)
-          (shared-limit-for-entry! conn entry limit dry-run))))))
+        (when (> (count (:shared entry)) 0)
+          (shared-dedup-and-limit-for-entry! conn entry limit dry-run))))))
 
 (defn shared-limit!
   "Given a batch size and offset load the orgs of that batch and run the shared limit,

--- a/src/oc/storage/resources/maintenance.clj
+++ b/src/oc/storage/resources/maintenance.clj
@@ -7,15 +7,16 @@
             [oc.storage.resources.org :as org-res]
             [oc.storage.resources.common :as common]))
 
-(defn- update-entry [conn entry original-entry]
+(defn- update-entry [conn entry original-entry dry-run]
   (schema/validate common/Entry entry)
   (timbre/info "--> Updating entry from" (count (:shared original-entry)) "to" (count (:shared entry)))
-  (db-common/update-resource conn common/entry-table-name :uuid original-entry entry (db-common/current-timestamp)))
+  (when-not dry-run
+    (db-common/update-resource conn common/entry-table-name :uuid original-entry entry (db-common/current-timestamp))))
 
 (schema/defn ^:always-validate shared-limit-for-entry!
   "Given a RethinkDB connection, an entry map and a limit to apply to share cut the list of
    shared to the passed value keeping only the newest"
-  [conn :- lib-schema/Conn entry :- common/Entry limit]
+  [conn :- lib-schema/Conn entry :- common/Entry limit dry-run]
   (let [old-shared (:shared entry)
         grouped-shared (group-by :shared-at old-shared)
         unique-shared (vec (map first (vals grouped-shared)))
@@ -24,7 +25,7 @@
     (timbre/info "      Old shared" (count old-shared))
     (timbre/info "      Unique shared" (count unique-shared))
     (timbre/info "      Limited shared" (count limited-shared))
-    (update-entry conn (assoc entry :shared limited-shared) entry)
+    (update-entry conn (assoc entry :shared limited-shared) entry dry-run)
     (timbre/info "      Cut!")))
 
 (schema/defn ^:always-validate list-all-entries-by-org!
@@ -34,24 +35,35 @@
 (schema/defn ^:always-validate shared-limit-for-org!
   "Give a RethinkDB connection and an org-uuid, load all the published entries of the org
    and call the shared-limit-for-entry on all that are exceeding the shared limit."
-  [conn :- lib-schema/Conn org-uuid :- lib-schema/UniqueID limit]
-  (timbre/info "  Cut for org" org-uuid)
+  [conn :- lib-schema/Conn org-uuid :- lib-schema/UniqueID limit dry-run]
   (let [entries (list-all-entries-by-org! conn org-uuid)]
     (timbre/info "  Entries count:" (count entries))
     (for [entry entries]
       (do
         (timbre/info "    Checking entry" (:uuid entry) "shared:" (count (:shared entry)))
         (when (> (count (:shared entry)) limit)
-          (shared-limit-for-entry! conn entry limit))))))
+          (shared-limit-for-entry! conn entry limit dry-run))))))
 
 (defn shared-limit!
   "List all the present orgs, for each load all the entries that have more then 20 shared entries
    and cut them to the 20 more recent values."
-  [conn batch-length batch-offset & [limit]]
-  (let [limit (or limit 50)]
+  [conn {:keys [batch-length batch-offset limit dry-run]}]
+  (let [batch-length (or batch-length 20)
+        batch-offset (or batch-offset 0)
+        dry-run (if (nil? dry-run)
+                  true
+                  dry-run)
+        limit (or limit 50)]
     (timbre/info "Cut :shared lists for all entries to:" limit "(orgs from " (* batch-length batch-offset) "to" (* batch-length (inc batch-offset)) ")")
+    (when dry-run
+      (timbre/info "---- Dry-run not updating ----"))
     (let [orgs (org-res/list-orgs conn)
-          batches (vec (partition batch-length orgs))
-          batch (vec (get batches batch-offset))]
+          partition-length (min batch-length (count orgs))
+          batches (into [] (partition partition-length orgs))
+          batch (into [] (get batches batch-offset))]
+      (timbre/info "Total orgs:" (count orgs) " batch: " (inc batch-offset) "/" (count batches))
+      (timbre/info "Current batch size:" (count batch))
       (for [org batch]
-        (shared-limit-for-org! conn (:uuid org) limit)))))
+        (do
+          (timbre/info "Checking:" (:slug org))
+          (shared-limit-for-org! conn (:uuid org) limit dry-run))))))

--- a/src/oc/storage/resources/maintenance.clj
+++ b/src/oc/storage/resources/maintenance.clj
@@ -2,7 +2,6 @@
   "fns to maintain storage resources."
   (:require [schema.core :as schema]
             [taoensso.timbre :as timbre]
-            [clojure.pprint :as pp]
             [oc.lib.db.common :as db-common]
             [oc.lib.schema :as lib-schema]
             [oc.storage.resources.org :as org-res]
@@ -19,7 +18,7 @@
   [conn :- lib-schema/Conn entry :- common/Entry limit]
   (let [old-shared (:shared entry)
         grouped-shared (group-by :shared-at old-shared)
-        unique-shared (into [] (map first (vals grouped-shared)))
+        unique-shared (vec (map first (vals grouped-shared)))
         sorted-shared (reverse (sort-by :shared-at unique-shared))
         limited-shared (take limit sorted-shared)]
     (timbre/info "      Old shared" (count old-shared))
@@ -52,7 +51,7 @@
   (let [limit (or limit 50)]
     (timbre/info "Cut :shared lists for all entries to:" limit "(orgs from " (* batch-length batch-offset) "to" (* batch-length (inc batch-offset)) ")")
     (let [orgs (org-res/list-orgs conn)
-          batches (into [] (partition batch-length orgs))
-          batch (into [] (get batches batch-offset))]
+          batches (vec (partition batch-length orgs))
+          batch (vec (get batches batch-offset))]
       (for [org batch]
         (shared-limit-for-org! conn (:uuid org) limit)))))

--- a/src/oc/storage/resources/maintenance.clj
+++ b/src/oc/storage/resources/maintenance.clj
@@ -41,7 +41,7 @@
     (for [entry entries]
       (do
         (timbre/info "    Checking entry" (:uuid entry) "shared:" (count (:shared entry)))
-        (when (> (count (:shared entry)) 0)
+        (when (pos? (count (:shared entry)))
           (shared-dedup-and-limit-for-entry! conn entry limit dry-run))))))
 
 (defn shared-limit!
@@ -64,8 +64,8 @@
       (timbre/info "---- Dry-run not updating ----"))
     (let [orgs (org-res/list-orgs conn)
           partition-length (min batch-length (count orgs))
-          batches (into [] (partition-all partition-length orgs))
-          batch (into [] (get batches batch-offset))]
+          batches (vec (partition-all partition-length orgs))
+          batch (vec (get batches batch-offset))]
       (timbre/info "Total orgs:" (count orgs) " batch: " batch-offset "/" (count batches))
       (timbre/info " Current batch size:" (count batch))
       (for [org batch]


### PR DESCRIPTION
Add a script that:
- load all the orgs in batches (batch size and index are input parameter)
- for each org load all the published entries
- for each entry that has more than 1 share
- group the shares by shared-at
- get only one value for each of them (the rest are duplicates)
- sort the remaining by reverse shared-at
- keep only the most recent 50 items

Let me know if you think this can work, i'll run a test on staging as first thing

To test:
- open your local `lein repl`
- `(go-db)`
- `(maint/shared-limit! conn {:batch-length 10 :batch-offset 0 :dry-run true)` (10 is the number of orgs per batch, 0 is the index of the batch)

NB: i ran this on staging and cleaned all the orgs, the one that had real problems was 18f, one entry had 65535 shares so it was timing out the DB when loaded, now it has only 16 and is visible again. Take a look if you want to make sure everything is still in place.