### PR TITLE
Better use of `api-common/rep`

### DIFF
--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -53,7 +53,7 @@
                             [] []
                             (:access-level ctx) (-> ctx :user :user-id))
                         entries)]
-    (api-common/rep (assemble-board org-slug board entry-reps ctx))))
+    (assemble-board org-slug board entry-reps ctx)))
 
   ;; Regular board
   ([conn org :guard map? board :guard map? ctx]
@@ -200,7 +200,7 @@
                               ;; retrieve the board again to get final list of members
                               (board-res/get-board conn (:uuid board-result)))]
           (notification/send-trigger! (notification/->trigger :add org {:new created-board :notifications notifications} user invitation-note))
-          {:created-board (assemble-board conn org created-board ctx)}))
+          {:created-board (api-common/rep (assemble-board conn org created-board ctx))}))
     
     (do (timbre/error "Failed creating board for org:" org-slug) false))))
 

--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -624,7 +624,7 @@
                         {:existing-org (api-common/rep org) :existing-board (api-common/rep board)
                          :existing-entry (api-common/rep entry) :existing-comments (api-common/rep comments)
                          :existing-reactions (api-common/rep reactions)
-                         :access-level (api-common/rep access-level)}
+                         :access-level access-level}
                         false))
   
   ;; Responses


### PR DESCRIPTION
I checked again all the places where i added `api-common/rep` to avoid deep merging/concat of Liberator context, here is a couple of places i think i used it in the wrong way.

To test:
- signup
- create a new board
- change board settings to public
- change board settings to private
- add people to the board