### PR TITLE
Remove initial NUX draft post. Wasn't getting used.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,12 +18,12 @@
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.4.1"]
     ;; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-devel "1.7.0"]
+    [ring/ring-devel "1.7.1"]
     ;; Web application library https://github.com/ring-clojure/ring
     ;; NB: clj-time pulled in by oc.lib
     ;; NB: joda-time pulled in by oc.lib via clj-time
     ;; NB: commons-codec pulled in by oc.lib
-    [ring/ring-core "1.7.0" :exclusions [clj-time joda-time commons-codec]]
+    [ring/ring-core "1.7.1" :exclusions [clj-time joda-time commons-codec]]
     ;; CORS library https://github.com/jumblerg/ring.middleware.cors
     [jumblerg/ring.middleware.cors "1.0.1"]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre
@@ -37,7 +37,7 @@
     ;; Utility functions https://github.com/weavejester/medley
     [medley "1.0.0"]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
-    [zprint "0.4.10"]
+    [zprint "0.4.12"]
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     [open-company/lib "0.16.21"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
@@ -89,7 +89,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.3.1"]
+        [jonase/eastwood "0.3.3"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]
@@ -127,7 +127,7 @@
         ;; Dead code finder https://github.com/venantius/yagni
         [venantius/yagni "0.1.6" :exclusions [org.clojure/clojure]]
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
-        [lein-zprint "0.3.10" :exclusions [org.clojure/clojure]]
+        [lein-zprint "0.3.12" :exclusions [org.clojure/clojure]]
       ]  
     }]
     :repl-config [:dev {
@@ -209,7 +209,8 @@
     ;; Disable some linters that are enabled by default
     ;; contant-test - just seems mostly ill-advised, logical constants are useful in something like a `->cond` 
     ;; wrong-arity - unfortunate, but it's failing on 3/arity of sqs/send-message
-    :exclude-linters [:constant-test :wrong-arity]
+    ;; implicit-dependencies - uhh, just seems broken
+    :exclude-linters [:constant-test :wrong-arity :implicit-dependencies]
     ;; Enable some linters that are disabled by default
     :add-linters [:unused-namespaces :unused-private-vars] ; :unused-locals]
 

--- a/resources/samples/drafts.edn
+++ b/resources/samples/drafts.edn
@@ -1,6 +1,0 @@
-[
-  {
-    :headline "10 things to know about %name%"
-    :body "<p><b>What is your favorite 📚, 🎬, 💽, or other creative work?</b></p><p><br></p><p><b>If you could choose anyone, who would you pick as your mentor?</b></p><p><br></p><p><b>If you could meet anyone, living or ⚰️, who would you meet?</b></p><p><br></p><p><b>What’s the hardest thing you’ve ever done?</b></p><p><br></p><p><b>If you could learn to do anything, what would it be?</b></p><p><br></p><p><b>What could you give a 40-minute presentation on with absolutely no preparation?</b></p><p><br></p><p><b>What takes up too much of your time?</b></p><p><br></p><p><b>What are some small things that make your day better?</b></p><p><br></p><p><b>What are you interested in that most people haven’t heard of?</b></p><p><br></p><p><b>Share a fun fact about yourself. (Hobby, favorite food, travel, secret talent, etc.)</b></p><p><br></p>" 
-  }
-]

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -105,7 +105,7 @@
   "Decisions"
   "Lessons learned"
   "People"
-  "Product Updates"
+  "Product updates"
   "Week in review"})
 
 (defonce forced-board-name "General")


### PR DESCRIPTION
https://trello.com/c/MXle3ZKn

Requires https://github.com/open-company/open-company-web/pull/738

This PR and the Web PR remove the NUX draft post for new users.

To test:

- Create a new org via Slack
- [x] No draft post?
- [x] No draft tooltip?
- Create a new org via email
- [x] No draft post?
- [x] No draft tooltip?
- Invite a contributor to the org
- Sign-in with the invited contributor
- [x] No draft post?
- [x] Not draft tooltip?
- Merge both
- Deploy both
- Take a shot of whiskey (deploy drinking game)