### PR TITLE
Kinesis s3 sns.

### DIFF
--- a/src/oc/storage/async/notification.clj
+++ b/src/oc/storage/async/notification.clj
@@ -81,14 +81,6 @@
                                  " on " (name (:resource-type trigger))
                                  ": " (-> trigger :current :uuid))
                   :message (json/generate-string trigger {:pretty true})})
-  (sns/publish
-    {:access-key config/aws-access-key-id
-     :secret-key config/aws-secret-access-key}
-     :topic-arn config/aws-sns-storage-topic-arn
-     :subject (str (name (:notification-type trigger))
-                   " on " (name (:resource-type trigger))
-                   ": " (-> trigger :current :uuid))
-     :message (json/generate-string trigger {:pretty true}))
   (timbre/info "Request sent to topic:" config/aws-sns-storage-topic-arn))
 
 ;; ----- Event loop -----

--- a/src/oc/storage/async/notification.clj
+++ b/src/oc/storage/async/notification.clj
@@ -90,10 +90,11 @@
       (catch Exception e
         (timbre/info "SNS failed with: " e)
         ;; If an exception occurred write to the kinesis firehouse.
-        (fh/put-record
-          config/aws-kinesis-stream-name
-          {:subject subject
-           :Message message}))))
+        (when config/aws-kinesis-stream-name
+          (fh/put-record
+           config/aws-kinesis-stream-name
+           {:subject subject
+            :Message message})))))
   (timbre/info "Request sent to topic:" config/aws-sns-storage-topic-arn))
 
 ;; ----- Event loop -----

--- a/src/oc/storage/async/notification.clj
+++ b/src/oc/storage/async/notification.clj
@@ -77,10 +77,10 @@
   (schema/validate NotificationTrigger trigger)
   (timbre/info "Sending request to topic:" config/aws-sns-storage-topic-arn)
   (fh/put-record config/aws-kinesis-stream-name
-                 { :subject (str (name (:notification-type trigger))
+                 {:subject (str (name (:notification-type trigger))
                                  " on " (name (:resource-type trigger))
                                  ": " (-> trigger :current :uuid))
-                  :message (json/generate-string trigger {:pretty true})})
+                  :Message (json/generate-string trigger {:pretty true})})
   (timbre/info "Request sent to topic:" config/aws-sns-storage-topic-arn))
 
 ;; ----- Event loop -----

--- a/src/oc/storage/async/notification.clj
+++ b/src/oc/storage/async/notification.clj
@@ -78,21 +78,22 @@
   (timbre/info "Sending request to topic:" config/aws-sns-storage-topic-arn)
   (let [subject (str (name (:notification-type trigger))
                      " on " (name (:resource-type trigger))
-                     ": " (-> trigger :current :uuid))]
+                     ": " (-> trigger :current :uuid))
+        message (json/generate-string trigger {:pretty true})]
     (try
       (sns/publish
        {:access-key config/aws-access-key-id
         :secret-key config/aws-secret-access-key}
        :topic-arn config/aws-sns-storage-topic-arn
        :subject subject
-       :message (json/generate-string trigger {:pretty true}))
+       :message message)
       (catch Exception e
         (timbre/info "SNS failed with: " e)
         ;; If an exception occurred write to the kinesis firehouse.
         (fh/put-record
           config/aws-kinesis-stream-name
           {:subject subject
-           :Message (json/generate-string trigger {:pretty true})}))))
+           :Message message}))))
   (timbre/info "Request sent to topic:" config/aws-sns-storage-topic-arn))
 
 ;; ----- Event loop -----

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -67,6 +67,7 @@
 (defonce aws-sqs-search-index-queue (env :aws-sqs-search-index-queue))
 
 (defonce aws-sns-storage-topic-arn (env :aws-sns-storage-topic-arn))
+(defonce aws-kinesis-stream-name (env :aws-kinesis-stream-name))
 
 ;; ----- Ziggeo Video Processing -----
 

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -68,6 +68,7 @@
 
 (defonce aws-sns-storage-topic-arn (env :aws-sns-storage-topic-arn))
 (defonce aws-kinesis-stream-name (env :aws-kinesis-stream-name))
+(defonce aws-kinesis-reindex-stream-name (env :aws-kinesis-reindex-stream-name))
 
 ;; ----- Ziggeo Video Processing -----
 

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -67,8 +67,8 @@
 (defonce aws-sqs-search-index-queue (env :aws-sqs-search-index-queue))
 
 (defonce aws-sns-storage-topic-arn (env :aws-sns-storage-topic-arn))
-(defonce aws-kinesis-stream-name (env :aws-kinesis-stream-name))
-(defonce aws-kinesis-reindex-stream-name (env :aws-kinesis-reindex-stream-name))
+(defonce aws-kinesis-stream-name (or (env :aws-kinesis-stream-name) false))
+(defonce aws-kinesis-reindex-stream-name (or (env :aws-kinesis-reindex-stream-name) false))
 
 ;; ----- Ziggeo Video Processing -----
 

--- a/src/oc/storage/util/search.clj
+++ b/src/oc/storage/util/search.clj
@@ -48,9 +48,10 @@
       (catch Exception e
         (timbre/info "SQS failed with: " e)
         ;; If an exception occurred write to the kinesis firehouse.
-        (fh/put-record
-         config/aws-kinesis-reindex-stream-name
-         message)))))
+        (when config/aws-kinesis-reindex-stream-name
+          (fh/put-record
+           config/aws-kinesis-reindex-stream-name
+           message))))))
 
 (defn index-all-entries [conn]
   (let [now (db-common/current-timestamp)]

--- a/src/oc/storage/util/search.clj
+++ b/src/oc/storage/util/search.clj
@@ -47,6 +47,7 @@
        message)
       (catch Exception e
         (timbre/info "SQS failed with: " e)
+        (timbre/info "sending to " config/aws-kinesis-reindex-stream-name)
         ;; If an exception occurred write to the kinesis firehouse.
         (when config/aws-kinesis-reindex-stream-name
           (fh/put-record


### PR DESCRIPTION
Needed: https://github.com/open-company/open-company-lib/pull/52

This change writes to a kinesis firehouse if an exception is thrown using SNS.  This is to help get around the limitations of SNS (size, 256kb limit, is the main concern here.)

Each service interested in the notification data from storage will have to use the new function provided in open-company-lib.

Service PRS:
https://github.com/open-company/open-company-notify/pull/7

https://github.com/open-company/open-company-change/pull/13

https://github.com/open-company/open-company-email/pull/40/

https://github.com/open-company/open-company-bot/pull/53

https://github.com/open-company/open-company-search/pull/13

Deploy with https://github.com/belucid/open-company-infrastructure/pull/96

To test:
- create a long post ~260k characters
- watch the aws cloudwatch logs or local logs for the `SNS failed with:`
- if the excpetion occurred, it would have been sent to kinesis
- [x] did the message show up in search?
- add a mention to the post
- [x] did it show up in email/bot as a notification?
- [x] Does the web client get a change message when the post is edited?
