### PR TITLE
Cleanup reminders when orgs get removed.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -87,7 +87,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.3.4"]
+        [jonase/eastwood "0.3.5"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]

--- a/src/oc/storage/resources/org.clj
+++ b/src/oc/storage/resources/org.clj
@@ -157,6 +157,10 @@
   (if-let [uuid (:uuid (get-org conn slug))]
     
     (do
+      ;; Delete reminders
+      (try
+        (db-common/delete-resource conn "reminders" :org-uuid uuid)
+        (catch java.lang.RuntimeException e)) ; OK if no reminders
       ;; Delete interactions
       (try
         (db-common/delete-resource conn common/interaction-table-name :org-uuid uuid)
@@ -265,7 +269,8 @@
   "Use with caution! Failure can result in partial deletes. Returns `true` if successful."
   [conn]
   {:pre [(db-common/conn? conn)]}
-  ;; Delete all interactions, entries, boards and orgs
+  ;; Delete all reminders, interactions, entries, boards and orgs
+  (db-common/delete-all-resources! conn "reminders")
   (db-common/delete-all-resources! conn common/interaction-table-name)
   (db-common/delete-all-resources! conn common/entry-table-name)
   (db-common/delete-all-resources! conn common/board-table-name)


### PR DESCRIPTION
To test:

- Have on org w/ at least 1 reminder
- See the reminder at the Reminder REPL with `(reminder/list-reminders conn "<ORG UUID")`
- Delete the org at the Storage REPL with `(org/delete-org! conn "<ORG SLUG>")`
- [x] Repeat the Reminder REPL command above, should be `[]`
- Merge
- Shake it like a Polaroid picture