### PR TITLE
Bug on publishing

### DIFF
--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -182,17 +182,24 @@
                             (entry-res/->entry conn board-uuid fixed-entry user))]
             (timbre/info "Upserting entry for new board:" board-uuid)
             (let [entry-result (entry-res/upsert-entry! conn new-entry user)]
+
               ;; Now publish all the entries that are not published already
-              (when (and (= entry-action :update)
-                         (= (keyword (:status new-entry)) :published)
-                         (not (:published-at new-entry)))
-                (entry-res/publish-entry! conn (:uuid new-entry) user))
-              (timbre/info "Upserted entry for new board:" board-uuid "as" (:uuid entry-result))
+              (if (and (= entry-action :update)
+                       (= (keyword (:status new-entry)) :published)
+                       (not (:published-at new-entry)))
+                
+                (do
+                  (entry-res/publish-entry! conn (:uuid new-entry) user)
+                  (timbre/info "Upserted and published entry for new board:" board-uuid "as" (:uuid entry-result)))
+                
+                (timbre/info "Upserted entry for new board:" board-uuid "as" (:uuid entry-result)))
+
               ;; If we are updating an existing draft check if we need to remove the old board
               (when (not= (:board-uuid entry) entry-res/temp-uuid)
                 (let [old-board (board-res/get-board conn (:board-uuid entry))
                       remaining-entries (entry-res/list-all-entries-by-board conn (:uuid old-board))]
                   (board-res/maybe-delete-draft-board conn org old-board remaining-entries user)))
+
               (when (= (:status entry-result) "published")
                 (when (= :add entry-action)
                   (entries-api/auto-share-on-publish conn (assoc ctx :existing-board board-result) entry-result))

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -173,8 +173,7 @@
         (doseq [viewer viewers] (add-member conn ctx (:slug org) (:slug board-result) :viewers viewer))
         ;; Add any entries specified in the request
         (doseq [entry entries]
-          (let [fixed-entry (-> entry
-                                (assoc :board-uuid board-uuid))
+          (let [fixed-entry (assoc entry :board-uuid board-uuid)
                 entry-action (if (entry-res/get-entry conn (:uuid entry))
                                :update
                                :add)


### PR DESCRIPTION
Bug:
- open Cmail
- enter title
- enter body
- wait for autosave to finish
- click on section
- click new section
- enter name of section and wait for preflight to complete
- now quickly save the new section and publish the entry right away

with the bug still in place you should get to a situation like the one below with a post that doesn't appear in AP because it's missing `:publisher` and `:published-at` even if the status is `published`.
Notice the author is missing in the image

<img src="https://ucbd9ca4fa5f780eaf563b62aae1.previews.dropboxusercontent.com/p/thumb/AAUd8BuX06CE-OuPgJH_5W_WHmStLdjMvN9cgAD3OUqL47qlLTDKK9niAd4lLVfnc4rk21u26V5HTTWLSarRWxcd9UIBpEXas6VnLLMMh_53pKQNT09OBxpd1fRLGvxsPpJct6PrCdwwGdeu_nSXbju7fofK6gH4_yCZpbKWOc2PMYFk3ZPeNHNsx60OCPqAhf5UoXSYPsv95h4ukuClHSahX5gQNeYwAJYSbtd85Zi6u7-LLu-fWHMDBoF2RemOanVuLxYCl5wzO-8ywxd0rE7OHzSYWQUpUhYoC_2Sh1WVdh9OoVdVfWM10C-i1ZNl_IzRvDkZrr3b3HDp8COGpUzBNXoQx_LlfcG9_m_b2VCbTw/p.png?size_mode=5">


Now repeat the test with this fix and check that the newly created post has an author and appears in AP.