### PR TITLE
Slack unfurl updates

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.1-beta2"]
+    [org.clojure/clojure "1.10.1-RC1"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.4.2"]
     ;; Web application library https://github.com/ring-clojure/ring
@@ -33,12 +33,12 @@
     ;; Web routing https://github.com/weavejester/compojure
     [compojure "1.6.1"]
     ;; Utility functions https://github.com/weavejester/medley
-    [medley "1.1.0"]
+    [medley "1.2.0"]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
     [zprint "0.4.15"]
     
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.17.5"]
+    [open-company/lib "0.17.8"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - HTTP client/server http://www.http-kit.org/
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun

--- a/src/oc/storage/representations/entry.clj
+++ b/src/oc/storage/representations/entry.clj
@@ -105,9 +105,7 @@
         board-uuid (:uuid board)
         board-slug (:slug board)
         draft? (= :draft (keyword (:status entry)))
-        full-entry (if draft?
-                      (merge {:board-slug (:slug board) :board-name (:name board)} entry)
-                      entry)
+        full-entry (merge {:board-slug board-slug :board-name (:name board)} entry)
         reaction-list (if (= access-level :public)
                         []
                         (content/reactions-and-links org-uuid board-uuid entry-uuid reactions user-id))
@@ -155,8 +153,7 @@
           ;; "stand-alone", so include extra props
           (-> org
             (clojure.set/rename-keys org-prop-mapping)
-            (merge full-entry)
-            (assoc :board-slug board-slug))
+            (merge full-entry))
           full-entry)
       (select-keys representation-props)
       (include-secure-uuid secure-uuid access-level)


### PR DESCRIPTION
Review with https://github.com/open-company/open-company-slack-router/pull/14

@belucid i assigned this to you since i am not sure this change has implications with security. Before we were adding the board-slug only if the post was loaded via the secure uuid and `board-slug` and `board-name` only if it was still a draft. I don't see a problem in always returning `board-slug` and `board-name` but i may be wrong.