### PR TITLE
Implement dynamic routing of share requests based on target user's no…

### DIFF
--- a/src/oc/storage/async/bot.clj
+++ b/src/oc/storage/async/bot.clj
@@ -5,7 +5,8 @@
             [schema.core :as schema]
             [oc.lib.schema :as lib-schema]
             [oc.lib.text :as str]
-            [oc.storage.config :as config]))
+            [oc.storage.config :as config]
+            [clojure.string :as cstr]))
 
 (def BotTrigger 
   "All Slack bot triggers have the following properties."
@@ -58,14 +59,15 @@
   "Given an entry for an org and a share request, create the share trigger."
   [org board entry share-request user]
   (let [slack-org-id (-> share-request :channel :slack-org-id)
+        slack-channel-id (-> share-request :channel :channel-id)
         comments (:existing-comments entry)
         comment-count (str (count comments))]
     {
       :type "share-entry"
       :receiver {
-        :type :channel
+        :type (if (cstr/starts-with? slack-channel-id "U") :user :channel)
         :slack-org-id slack-org-id
-        :id (-> share-request :channel :channel-id)
+        :id slack-channel-id
       }
       :bot (bot-for slack-org-id user)
       :note (str/strip-xss-tags (:note share-request))

--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -73,13 +73,17 @@
 (def ShareMedium (schema/pred #(#{:email :slack} (keyword %))))
 
 (def ShareRequest {
-  :medium ShareMedium
+  ;; Requesting client can specify :medium OR :user-id. In the
+  ;; latter case the target user's notification preferences
+  ;; will be queried and used as the medium
+  (schema/optional-key :medium) ShareMedium
+  (schema/optional-key :user-id) lib-schema/UniqueID
   (schema/optional-key :note) (schema/maybe schema/Str)
-  
+
   ;; Email medium
   (schema/optional-key :to) [lib-schema/EmailAddress]
   (schema/optional-key :subject) (schema/maybe schema/Str)
-  
+
   ;; Slack medium
   (schema/optional-key :channel) lib-schema/SlackChannel
 


### PR DESCRIPTION
Card: https://trello.com/c/9m4ZQpnb/2051-wst-updates-backend

## Testing

1. Onboard a new organization, hence known as `Owner` user.
2. Invite a contributor **via email**, hence known as `Contrib` user
3. With `Owner` create a new post in any board
4. Open the WST panel, and send this post to `Contrib` via the "Notify" link
- [x] Did `Contrib` receive an email notification?

<hr />

_No slack bot is installed! Test that Slack reminders should fall back to email._

1. Onboard another contributor **via slack**, hence known as `Contrib 2`
2. Verify `Contrib 2's` notification settings, should have "Reminders" set to "email"
3. With `Owner`, send the same post to `Contrib 2`
- [ ] Did `Contrib 2` receive an email?

<hr />

1. With `Owner`, install the slack bot
2. With `Owner`, send the same post to `Contrib 2` again
- [ ] Did `Contrib 2` receive the reminder via the slack bot this time?

<hr />

1. With `Contrib 2`, change "Reminders" notification setting to "Email"
2. With `Owner`, send the same post to `Contrib 2`
- [ ] Did `Contrib 2` receive the post via email this time?

<hr />

1. Create a new post with `Contrib` or `Contrib 2` in any board
2. Send this post to `Owner`
- [ ] Did `Owner` receive the notification via the proper medium? (This depends on how how you on-boarded the owner user)

<hr />

1. Onboard a brand new organization, hence known as `Owner 2`
2. Invite the exact same `Contrib` user via email that you did in the initial test
3. With `Owner 2`, create a new post in any board
4. Send the post to `Contrib`
- [ ] Did `Contrib` receive the email notification from the proper org?

<hr />

1. Try adjusting `Owner 2's` notification "Reminder" setting to "Slack" and "Email"
2. With `Contrib`, send a post to `Owner 2`
- [ ] Did `Owner 2` receive the notification from the configured medium?