### PR TITLE
Abstracts

### DIFF
--- a/src/oc/storage/async/bot.clj
+++ b/src/oc/storage/async/bot.clj
@@ -32,6 +32,7 @@
     :board-slug lib-schema/NonBlankStr
     :entry-uuid lib-schema/UniqueID
     :headline (schema/maybe schema/Str)
+    :abstract (schema/maybe schema/Str)
     :body (schema/maybe schema/Str)
     :must-see (schema/maybe schema/Bool)
     :video-id (schema/maybe lib-schema/NonBlankStr)
@@ -76,6 +77,7 @@
       :org-logo-url (:logo-url org)
       :entry-uuid (:uuid entry)
       :headline (:headline entry)
+      :abstract (:abstract entry)
       :body (:body entry)
       :must-see (:must-see entry)
       :video-id (:video-id entry)

--- a/src/oc/storage/async/email.clj
+++ b/src/oc/storage/async/email.clj
@@ -22,6 +22,7 @@
    :org-logo-height (schema/maybe schema/Int)
    :board-name (schema/maybe schema/Str)
    :headline schema/Str
+   :abstract (schema/maybe schema/Str)
    :body (schema/maybe schema/Str)
    :must-see (schema/maybe schema/Bool)
    :video-id (schema/maybe schema/Str)
@@ -47,6 +48,7 @@
    :org-logo-height (:logo-height org)
    :board-name (:name board)
    :headline (:headline entry)
+   :abstract (:abstract entry)
    :body (:body entry)
    :must-see (:must-see entry)
    :video-id (:video-id entry)


### PR DESCRIPTION
Card: https://trello.com/c/Ry531RUJ/2053-use-abstract-for-posts-when-there-is-one-thats-not-nil-blank

Dependent PRs _(test all of these together)_:
https://github.com/open-company/open-company-digest/pull/22
https://github.com/open-company/open-company-bot/pull/82
https://github.com/open-company/open-company-email/pull/50
https://github.com/open-company/open-company-slack-router/pull/15

To test:
- Make a few posts that contain abstracts
- Make a few posts that do NOT contain abstracts, and that possess relatively long bodies (lorem ipsum should work)
- Send an abstract post to an email user and a slack user (from WST panel)
- [ ] Is the abstract properly displayed as the post body in the email?
- Send a NON-abstract post to an email user and a slack user (from WST panel)
- [ ] Is the truncated body properly displayed as the body in the email?
- Trigger a slack digest for your slack user
- [x] Are post's with abstracts displayed as such, and posts without abstracts still correctly displaying a truncated body?
- Trigger an email digest for your email user
- [x] Are post's with abstracts displayed as such, and posts without abstracts still correctly displaying a truncated body?
- [ ] Slack unfurl of both types of post
- [x] Legacy Carrot 1 client test, share to Slack channel 
- [ ] Slack auto-share w/ abstract
- [ ] Slack auto-share w/o abstract