### PR TITLE
Fix autoshare error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.1-RC1"]
+    [org.clojure/clojure "1.10.1"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.4.2"]
     ;; Web application library https://github.com/ring-clojure/ring

--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -154,7 +154,8 @@
   [conn ctx entry-result]
   (when (or (nil? (:video-id entry-result))
             (true? (:video-processed entry-result)))
-    (if-let* [slack-channel (:slack-mirror (:existing-board ctx))]
+    (if-let* [slack-channel (:slack-mirror (:existing-board ctx))
+              _can-slack-share (bot/has-slack-bot-for (:slack-org-id slack-channel) (:user ctx))]
       (let [share-request {:medium "slack"
                            :note ""
                            :shared-at (db-common/current-timestamp)

--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -155,7 +155,7 @@
   (when (or (nil? (:video-id entry-result))
             (true? (:video-processed entry-result)))
     (if-let* [slack-channel (:slack-mirror (:existing-board ctx))
-              _can-slack-share (bot/has-slack-bot-for (:slack-org-id slack-channel) (:user ctx))]
+              _can-slack-share (bot/has-slack-bot-for? (:slack-org-id slack-channel) (:user ctx))]
       (let [share-request {:medium "slack"
                            :note ""
                            :shared-at (db-common/current-timestamp)

--- a/src/oc/storage/async/bot.clj
+++ b/src/oc/storage/async/bot.clj
@@ -45,12 +45,21 @@
     :shared-at lib-schema/ISO8601
     }))
 
-(defn- bot-for
-  "Extract the right bot from the JWToken for the specified Slack org ID."
-  [slack-org-id user]
+(defn- get-slack-bot-for [slack-org-id user]
   (let [slack-bots (flatten (vals (:slack-bots user)))
         slack-bots-by-slack-org (zipmap (map :slack-org-id slack-bots) slack-bots)
         slack-bot (get slack-bots-by-slack-org slack-org-id)]
+    slack-bot))
+
+(defn has-slack-bot-for [slack-org-id user]
+  (let [slack-bot (get-slack-bot-for slack-org-id user)]
+    (and (map? slack-bot)
+         (not (empty? slack-bot)))))
+
+(defn- bot-for
+  "Extract the right bot from the JWToken for the specified Slack org ID."
+  [slack-org-id user]
+  (let [slack-bot (get-slack-bot-for slack-org-id user)]
     (if slack-bot
       {:token (:token slack-bot) :id (:id slack-bot)}
       false)))

--- a/src/oc/storage/async/bot.clj
+++ b/src/oc/storage/async/bot.clj
@@ -51,10 +51,10 @@
         slack-bot (get slack-bots-by-slack-org slack-org-id)]
     slack-bot))
 
-(defn has-slack-bot-for [slack-org-id user]
+(defn has-slack-bot-for? [slack-org-id user]
   (let [slack-bot (get-slack-bot-for slack-org-id user)]
     (and (map? slack-bot)
-         (not (empty? slack-bot)))))
+         (seq (keys slack-bot)))))
 
 (defn- bot-for
   "Extract the right bot from the JWToken for the specified Slack org ID."


### PR DESCRIPTION
Bug: if you have a section set to autoshare to Slack but then remove the bot or the Slack org  we still try to publish. It can work if the user still has the bot stuff in the JWT but if not it was breaking the publish action.

To test:
- signup with a new Slack org (remove it from your DB if you need to)
- add the bot
- add a section with auto share to a slack channel
- [x] publish a post to that section
- [x] post is in slack?
- now go to settings and remove the slack org completely
- without refreshing and logging out or in go to that sectiona again
- publish a post to that section
- [x] post was published?
- [x] post is in Slack? (this happens because you still have the bot in the JWT)
- now logout and back in (or `OCWebForceRefreshToken()` in console)
- publish a post to the same section
- [x] publish worked w/o errors?
- [x] no post in Slack this time and no errors in Storage log?