### PR TITLE
Fix reactions count

### DIFF
--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -65,7 +65,7 @@
                      :previous-count (count previous-activity)
                      :next-count (count next-activity)
                      :entries (map #(entry-rep/render-entry-for-collection org board %
-                                     (entry-rep/comments %) (entry-rep/reactions %)
+                                     (entry-rep/comments %) (reaction-res/aggregate-reactions (entry-rep/reactions %))
                                      access-level user-id)
                                (concat (reverse previous-activity) next-activity))})
 
@@ -75,7 +75,7 @@
                     {:direction :previous
                      :previous-count (count previous-activity)
                      :entries (map #(entry-rep/render-entry-for-collection org board %
-                                     (entry-rep/comments %) (entry-rep/reactions %)
+                                     (entry-rep/comments %) (reaction-res/aggregate-reactions (entry-rep/reactions %))
                                      access-level user-id)
                                 (reverse previous-activity))})
 
@@ -85,7 +85,7 @@
                     {:direction :next
                      :next-count (count next-activity)
                      :entries (map #(entry-rep/render-entry-for-collection org board %
-                                     (entry-rep/comments %) (entry-rep/reactions %)
+                                     (entry-rep/comments %) (reaction-res/aggregate-reactions (entry-rep/reactions %))
                                      access-level user-id)
                                next-activity)}))
         fixed-activities (update activities :entries #(map (fn [activity] (merge activity {


### PR DESCRIPTION
Bug: sometimes the reactions are returned in plain list from storage not grouped by emoji. The client is not always showing them that way since it depends if a certain post was loaded from the activity or the board API for last (we keep only one version of each post in the web client so the last loaded remains).

To test:
- with mainline
- with user 1 go to AP
- add a post to board A
- add a reaction with user 1
- add the same reaction and another with user 2
- now with user 1 nav to board A (from AP)
- you should see 3 reactions instead of 2 and w/o a count besides it
- now switch to this branch
- go to AP
- refresh
- nav to board A
- 💥 