### PR TITLE
Recent activity sort fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [zprint "0.4.16"]
     
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.17.14"]
+    [open-company/lib "0.17.18"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - HTTP client/server http://www.http-kit.org/
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun

--- a/src/oc/storage/representations/entry.clj
+++ b/src/oc/storage/representations/entry.clj
@@ -149,10 +149,11 @@
         board-slug (:slug board)
         board-access (:access board)
         draft? (= :draft (keyword (:status entry)))
+        entry-with-comments (merge entry :interactions comments)
         full-entry (merge {:board-slug board-slug
                            :board-access board-access
                            :board-name (:name board)
-                           :new-at (-> (sort/max-comment-timestamp user-id entry comments)
+                           :new-at (-> (sort/entry-new-at user-id entry-with-comments true)
                                     vals
                                     first)} entry)
         reaction-list (if (= access-level :public)

--- a/src/oc/storage/representations/entry.clj
+++ b/src/oc/storage/representations/entry.clj
@@ -149,7 +149,7 @@
         board-slug (:slug board)
         board-access (:access board)
         draft? (= :draft (keyword (:status entry)))
-        entry-with-comments (merge entry :interactions comments)
+        entry-with-comments (assoc entry :interactions comments)
         full-entry (merge {:board-slug board-slug
                            :board-access board-access
                            :board-name (:name board)


### PR DESCRIPTION
Card: https://trello.com/c/5dfbiYTG

To test:
- user A go to AP in recent activity sort
- user B go to AP in recent activity sort
- add post A with user A
- add post B with user B
- [x] user A and B see them sorted the same
- add a comment with user A on post B
- [x] user A and B see them sorted the same
- [x] user B sees the NEW badge on post B but not user A
- add a comment with user A on post A
- [x] user A and B see them sorted the same
- [ ] user B sees the NEW badge on post A but not user A (reviewer's note: no, but that's because post A is unread by user B)
- add a comment with user B on post A
- [ ] user A and B see them sorted the same
- [x] user A sees the NEW badge on post A but not user B
- add a comment with user B on post B
- [x] user A and B see them sorted the same
- [x] user A sees the NEW badge on post B but not user B


NB: NEW badge is important to check. In the sort we still need to exclude the current user comments when looking for the max comment created-at. This is because when a user expand a post it marks it as read but then a comment is added so the new comment timestamp will result as added after the read and the UI will show the NEW badge.