### PR TITLE
Fix comment threads

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [zprint "0.4.16"]
     
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.17.14"]
+    [open-company/lib "0.17.17"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - HTTP client/server http://www.http-kit.org/
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -43,13 +43,15 @@
 
 ;; ----- URLs -----
 
-(defonce auth-server-url (or (env :auth-server-url) "http://localhost:3003"))
-(defonce interaction-server-url (or (env :interaction-server-url) "http://localhost:3002"))
-(defonce interaction-server-ws-url (or (env :interaction-server-ws-url) "ws://localhost:3002"))
-(defonce change-server-url (or (env :change-server-url) "http://localhost:3006"))
-(defonce change-server-ws-url (or (env :change-server-ws-url) "ws://localhost:3006"))
-(defonce notify-server-ws-url (or (env :notify-server-ws-url) "ws://localhost:3010"))
-(defonce reminder-server-url (or (env :reminder-server-url) "http://localhost:3011"))
+(defonce ip-address "localhost")
+
+(defonce auth-server-url (or (env :auth-server-url) (str "http://" ip-address ":3003")))
+(defonce interaction-server-url (or (env :interaction-server-url) (str "http://" ip-address ":3002")))
+(defonce interaction-server-ws-url (or (env :interaction-server-ws-url) (str "ws://" ip-address ":3002")))
+(defonce change-server-url (or (env :change-server-url) (str "http://" ip-address ":3006")))
+(defonce change-server-ws-url (or (env :change-server-ws-url) (str "ws://" ip-address ":3006")))
+(defonce notify-server-ws-url (or (env :notify-server-ws-url) (str "ws://" ip-address ":3010")))
+(defonce reminder-server-url (or (env :reminder-server-url) (str "http://" ip-address ":3011")))
 
 ;; ----- Liberator -----
 

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -43,15 +43,15 @@
 
 ;; ----- URLs -----
 
-(defonce ip-address "localhost")
+(defonce host "localhost")
 
-(defonce auth-server-url (or (env :auth-server-url) (str "http://" ip-address ":3003")))
-(defonce interaction-server-url (or (env :interaction-server-url) (str "http://" ip-address ":3002")))
-(defonce interaction-server-ws-url (or (env :interaction-server-ws-url) (str "ws://" ip-address ":3002")))
-(defonce change-server-url (or (env :change-server-url) (str "http://" ip-address ":3006")))
-(defonce change-server-ws-url (or (env :change-server-ws-url) (str "ws://" ip-address ":3006")))
-(defonce notify-server-ws-url (or (env :notify-server-ws-url) (str "ws://" ip-address ":3010")))
-(defonce reminder-server-url (or (env :reminder-server-url) (str "http://" ip-address ":3011")))
+(defonce auth-server-url (or (env :auth-server-url) (str "http://" host ":3003")))
+(defonce interaction-server-url (or (env :interaction-server-url) (str "http://" host ":3002")))
+(defonce interaction-server-ws-url (or (env :interaction-server-ws-url) (str "ws://" host ":3002")))
+(defonce change-server-url (or (env :change-server-url) (str "http://" host ":3006")))
+(defonce change-server-ws-url (or (env :change-server-ws-url) (str "ws://" host ":3006")))
+(defonce notify-server-ws-url (or (env :notify-server-ws-url) (str "ws://" host ":3010")))
+(defonce reminder-server-url (or (env :reminder-server-url) (str "http://" host ":3011")))
 
 ;; ----- Liberator -----
 

--- a/src/oc/storage/resources/entry.clj
+++ b/src/oc/storage/resources/entry.clj
@@ -32,6 +32,10 @@
   "Set of properties we want when listing entries."
   ["uuid" "headline" "body" "reaction" "author" "created-at" "updated-at"])
 
+(def list-comment-properties
+  "Set of peroperties we want when retrieving comments"
+  ["uuid" "body" "reaction" "author" "parent-uuid" "created-at" "updated-at"])
+
 ;; ----- Utility functions -----
 
 (defn clean
@@ -336,7 +340,7 @@
   "Given the UUID of the entry, return a list of the comments for the entry."
   [conn uuid :- lib-schema/UniqueID]
   {:pre [(db-common/conn? conn)]}
-  (filter :body (db-common/read-resources conn common/interaction-table-name "resource-uuid" uuid [:uuid :author :body :created-at])))
+  (filter :body (db-common/read-resources conn common/interaction-table-name "resource-uuid" uuid list-comment-properties)))
 
 (schema/defn ^:always-validate list-reactions-for-entry
   "Given the UUID of the entry, return a list of the reactions for the entry."
@@ -369,8 +373,7 @@
       "published-at" order start direction
       filter-map
       :interactions common/interaction-table-name :uuid :resource-uuid
-      ["uuid" "headline" "body" "reaction" "author"
-       "published-at" "created-at" "updated-at"] {:count count}))))
+      list-comment-properties {:count count}))))
 
 
 (schema/defn ^:always-validate paginated-entries-by-board
@@ -386,8 +389,7 @@
     :status-board-uuid [[:published board-uuid]]
     "published-at" order start direction
     :interactions common/interaction-table-name :uuid :resource-uuid
-    ["uuid" "headline" "body" "reaction" "author"
-     "published-at" "created-at" "updated-at"] {:count count}))
+    list-comment-properties {:count count}))
 
 (schema/defn ^:always-validate list-entries-by-org-author
   "
@@ -403,7 +405,7 @@
          (#{:published :draft} status)]}
   (db-common/read-resources-and-relations conn table-name :status-org-uuid-author-id [[status org-uuid user-id]]
                                           :interactions common/interaction-table-name :uuid :resource-uuid
-                                          list-properties {:count count})))
+                                          list-comment-properties {:count count})))
 
 (schema/defn ^:always-validate list-entries-by-board
   "Given the UUID of the board, return the published entries for the board with any interactions."
@@ -411,7 +413,7 @@
   {:pre [(db-common/conn? conn)]}
   (db-common/read-resources-and-relations conn table-name :status-board-uuid [[:published board-uuid]]
                                           :interactions common/interaction-table-name :uuid :resource-uuid
-                                          list-properties {:count count}))
+                                          list-comment-properties {:count count}))
 
 (schema/defn ^:always-validate list-all-entries-by-board
   "Given the UUID of the board, return all the entries for the board."
@@ -431,8 +433,7 @@
       :org-uuid-status-follow-ups-completed?-assignee-user-id-map-multi [[org-uuid :published false user-id]]
       "published-at" order start direction
       :interactions common/interaction-table-name :uuid :resource-uuid
-      ["uuid" "headline" "body" "reaction" "author"
-       "published-at" "created-at" "updated-at"] {:count count})))
+      list-comment-properties {:count count})))
 
 ;; ----- Entry follow-up manipulation -----
 


### PR DESCRIPTION
Bug: right now storage doesn't send the `parent-uuid` properties with the list of comments when they are included in the entry. To test this:
- go to an entry
- add a few replies to different comments
- stop interaction service
- refresh the page
-  💥 all comments are shown as root comments

Fix: this simply make sure the parent-uuid is included in the comments.

To test:
- repeat the test steps above and make sure the comments are threaded as they should be

NB: can be that you don't see all the comments when refreshing the post with IS down, that's because storage only sends the first 10 comments with each entry and a total count.