### PR TITLE
Add gzip compression ring middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,8 @@
     [ring/ring-core "1.7.1" :exclusions [clj-time joda-time commons-codec]]
     ;; CORS library https://github.com/jumblerg/ring.middleware.cors
     [jumblerg/ring.middleware.cors "1.0.1"]
+    ;; GZIP your Ring responses https://github.com/clj-commons/ring-gzip-middleware
+    [amalloy/ring-gzip-middleware "0.1.4"]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre
     ;; NB: com.taoensso/encore pulled in by oc.lib
     ;; NB: com.taoensso/timbre pulled in by oc.lib

--- a/src/oc/storage/app.clj
+++ b/src/oc/storage/app.clj
@@ -11,6 +11,7 @@
     [ring.middleware.params :refer (wrap-params)]
     [ring.middleware.reload :refer (wrap-reload)]
     [ring.middleware.cors :refer (wrap-cors)]
+    [ring.middleware.gzip :refer (wrap-gzip)]
     [compojure.core :as compojure :refer (GET)]
     [com.stuartsierra.component :as component]
     [oc.lib.sentry-appender :as sa]
@@ -76,7 +77,8 @@
     true              wrap-params
     c/liberator-trace (wrap-trace :header :ui)
     true              (wrap-cors #".*")
-    c/hot-reload      wrap-reload))
+    c/hot-reload      wrap-reload
+    true              wrap-gzip))
 
 (defn start
   "Start a development server"


### PR DESCRIPTION
Trello: https://trello.com/c/6n0ugU0e/2269-use-gzip-compression-on-storage-service

To test:
- [ ] Content still loads successfully?
- [ ] Response headers show gzip compression on storage requests?