### PR TITLE
Fix boards pagination

### DIFF
--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -18,26 +18,14 @@
             [oc.storage.async.notification :as notification]
             [oc.storage.representations.media-types :as mt]
             [oc.storage.representations.board :as board-rep]
-            [oc.storage.representations.entry :as entry-rep]
             [oc.storage.resources.common :as common-res]
             [oc.storage.resources.org :as org-res]
             [oc.storage.resources.board :as board-res]
             [oc.storage.resources.entry :as entry-res]
-            [oc.storage.resources.reaction :as reaction-res]
             [oc.storage.lib.timestamp :as ts]
             [oc.storage.urls.board :as board-url]))
 
 ;; ----- Utility functions -----
-
-(defn- comments
-  "Return a sequence of just the comments for an entry."
-  [{interactions :interactions}]
-  (filter :body interactions))
-
-(defn- reactions
-  "Return a sequence of just the reactions for an entry."
-  [{interactions :interactions}]
-  (filter :reaction interactions))
 
 (defn- assemble-paginated-board
   "Assemble the requested activity (params) for the provided board."

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -68,7 +68,7 @@
     (assemble-board org-slug board entries ctx)))
 
   ;; Recursion to finish up both kinds of boards
-  ([org-slug :guard string? board :guard map? entry-reps :guard seq? ctx]
+  ([org-slug :guard string? board :guard map? entry-reps :guard coll? ctx]
   (let [slug (:slug board)
         authors (:authors board)
         author-reps (map #(board-rep/render-author-for-collection org-slug slug % (:access-level ctx)) authors)

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -48,14 +48,13 @@
         entries (entry-res/paginated-entries-by-board conn (:uuid board) order start direction
                  config/default-activity-limit sort-type {:must-see must-see})
         activities {:next-count (count entries)
-                    :direction direction
-                    :entries entries}
-        fixed-activities (update activities :entries #(map (fn [activity] (merge activity {
-                                                        :board-slug (:slug board)
-                                                        :board-name (:name board)}))
-                            %))]
+                    :direction direction}]
     ;; Give each activity its board name
-    (merge board fixed-activities)))
+    (merge board activities {:entries (map (fn [activity]
+                                            (merge activity {
+                                             :board-slug (:slug board)
+                                             :board-name (:name board)}))
+                                       entries)})))
 
 (defun- assemble-board
   "Assemble the entry, author, and viewer data needed for a board response."

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -49,10 +49,7 @@
                  config/default-activity-limit sort-type {:must-see must-see})
         activities {:next-count (count entries)
                     :direction direction
-                    :entries (map #(entry-rep/render-entry-for-collection org board %
-                                    (entry-rep/comments %) (reaction-res/aggregate-reactions (entry-rep/reactions %))
-                                    access-level user-id)
-                              entries)}
+                    :entries entries}
         fixed-activities (update activities :entries #(map (fn [activity] (merge activity {
                                                         :board-slug (:slug board)
                                                         :board-name (:name board)}))
@@ -73,24 +70,15 @@
                   all-drafts)
         board-uuids (distinct (map :board-uuid entries))
         boards (filter map? (map #(board-res/get-board conn %) board-uuids))
-        board-map (zipmap (map :uuid boards) boards)
-        entry-reps (map #(entry-rep/render-entry-for-collection org (or (board-map (:board-uuid %)) board) %
-                            [] []
-                            (:access-level ctx) (-> ctx :user :user-id))
-                        entries)]
-    (assemble-board org-slug board entry-reps ctx)))
+        board-map (zipmap (map :uuid boards) boards)]
+    (assemble-board org-slug board entries ctx)))
 
   ;; Regular board
   ([conn org :guard map? board :guard map? ctx]
   (let [org-slug (:slug org)
         slug (:slug board)
-        entries (entry-res/list-entries-by-board conn (:uuid board) {}) ; all entries for the board
-        entry-reps (map #(entry-rep/render-entry-for-collection org board %
-                            (comments %)
-                            (reaction-res/aggregate-reactions (reactions %))
-                            (:access-level ctx) (-> ctx :user :user-id))
-                      entries)]
-    (assemble-board org-slug board entry-reps ctx)))
+        entries (entry-res/list-entries-by-board conn (:uuid board) {})] ; all entries for the board
+    (assemble-board org-slug board entries ctx)))
 
   ;; Recursion to finish up both kinds of boards
   ([org-slug :guard string? board :guard map? entry-reps :guard seq? ctx]

--- a/src/oc/storage/db/common.clj
+++ b/src/oc/storage/db/common.clj
@@ -44,12 +44,14 @@
                                            left
                                            right)))
                                        (r/default (r/fn [_err]
-                                        {"created-at" (if (r/eq (r/get-field post-row "status") "published")
+                                        {"created-at" (if (r/has-fields post-row "published-at")
                                                         (r/get-field post-row "published-at")
                                                         (r/get-field post-row "created-at"))}))
                                        (r/do (r/fn [interaction-row]
                                          (r/get-field interaction-row "created-at"))))}
-                {:last-activity-at (r/get-field post-row :published-at)})))
+                {:last-activity-at (if (r/has-fields post-row "published-at")
+                                     (r/get-field post-row "published-at")
+                                     (r/get-field post-row "created-at"))})))
             (if (sequential? allowed-boards)
               ;; Filter out entries that don't belong
               (r/filter query (r/fn [post-row]

--- a/src/oc/storage/representations/board.clj
+++ b/src/oc/storage/representations/board.clj
@@ -52,9 +52,7 @@
   (let [activity (:entries data)
         activity? (not-empty activity)
         last-activity (last activity)
-        first-activity (first activity)
-        last-activity-date (when activity? (or (:published-at last-activity) (:created-at last-activity)))
-        first-activity-date (when activity? (or (:published-at first-activity) (:created-at first-activity)))
+        last-activity-date (when activity? (:last-activity-at last-activity))
         next? (= (:next-count data) config/default-activity-limit)
         next-url (when next? (board-url/url org board sort-type {:start last-activity-date :direction direction}))
         next-link (when next-url (hateoas/link-map "next" hateoas/GET next-url {:accept mt/board-media-type}))]

--- a/src/oc/storage/representations/board.clj
+++ b/src/oc/storage/representations/board.clj
@@ -7,7 +7,8 @@
             [oc.storage.representations.org :as org-rep]
             [oc.storage.resources.board :as board-res]
             [oc.storage.urls.board :as board-url]
-            [oc.storage.representations.entry :as entry-rep]))
+            [oc.storage.representations.entry :as entry-rep]
+            [oc.storage.resources.reaction :as reaction-res]))
 
 (def public-representation-props [:uuid :slug :name :access :promoted :entries :created-at :updated-at :links])
 (def representation-props (concat public-representation-props [:slack-mirror :author :authors :viewers :draft]))
@@ -110,7 +111,7 @@
 (defn render-entry-for-collection
   "Create a map of the activity for use in a collection in the API"
   [org board entry access-level user-id]
-  (entry-rep/render-entry-for-collection org board entry (entry-rep/comments entry) (entry-rep/reactions entry) access-level user-id))
+  (entry-rep/render-entry-for-collection org board entry (entry-rep/comments entry) (reaction-res/aggregate-reactions (entry-rep/reactions entry)) access-level user-id))
 
 (defn render-board-for-collection
   "Create a map of the board for use in a collection in the REST API"

--- a/src/oc/storage/representations/board.clj
+++ b/src/oc/storage/representations/board.clj
@@ -48,7 +48,7 @@
 
 (defn- pagination-link
   "Add `next` links for pagination as needed."
-  [org board sort-type {:keys [start]} data]
+  [org board sort-type {:keys [start direction]} data]
   (let [activity (:entries data)
         activity? (not-empty activity)
         last-activity (last activity)
@@ -56,7 +56,7 @@
         last-activity-date (when activity? (or (:published-at last-activity) (:created-at last-activity)))
         first-activity-date (when activity? (or (:published-at first-activity) (:created-at first-activity)))
         next? (= (:next-count data) config/default-activity-limit)
-        next-url (when next? (board-url/url org board sort-type {:start last-activity-date}))
+        next-url (when next? (board-url/url org board sort-type {:start last-activity-date :direction direction}))
         next-link (when next-url (hateoas/link-map "next" hateoas/GET next-url {:accept mt/board-media-type}))]
     next-link))
 

--- a/src/oc/storage/representations/board.clj
+++ b/src/oc/storage/representations/board.clj
@@ -133,5 +133,7 @@
     (json/generate-string
       (-> board
         (board-links (:slug org) sort-type access-level params)
+        (assoc :entries (map #(render-entry-for-collection org board % access-level (-> ctx :user :user-id))
+                         (:entries board)))
         (select-keys rep-props))
       {:pretty config/pretty?})))

--- a/src/oc/storage/urls/board.clj
+++ b/src/oc/storage/urls/board.clj
@@ -4,7 +4,7 @@
 (defun url
   ([org-slug board-slug :guard string? sort-type :guard keyword? params :guard map?]
     (let [concat-str (if (= sort-type :recent-activity) "&" "?")]
-      (str (url org-slug board-slug sort-type) concat-str "start=" (:start params))))
+      (str (url org-slug board-slug sort-type) concat-str "start=" (:start params) "&direction=" (name (:direction params)))))
   ([org-slug board :guard map?]
     (url org-slug (:slug board) :recently-posted))
   ([org-slug slug :guard string?]


### PR DESCRIPTION
Bug: pagination on boards is broken because they are missing the direction parameter and also the start parameter is not passed in properly.

To test:
- test pagination on an arbitrary board
- test drafts board with less than 10 posts
- test drafts board with more than 10 posts
- test pagination in AP
- test pagination in Follow Ups
- every other test you can thing around board representation and pagination
- check reactions are aggregated properly in boards
- check reactions are aggregated properly in AP/Unread/Bookmarks
- check first 10 comments are returned properly from board endpoint
- check first 10 comments are returned properly from AP/Unread/Bookmarks endpoint