### PR TITLE
Fix board creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ pom.xml.asc
 /.nrepl-port
 .idea/
 
+.eastwood
+
 /opt/open-company-interaction
 
 .ruby-gemset

--- a/src/oc/storage/api/activity.clj
+++ b/src/oc/storage/api/activity.clj
@@ -19,8 +19,8 @@
 
 (defn- assemble-activity
   "Assemble the requested (by the params) activity for the provided org."
-  [conn {start :start direction :direction must-see :must-see digest-request :digest-request}
-   org sort-type board-by-uuid allowed-boards user-id]
+  [conn {start :start direction :direction must-see :must-see digest-request :digest-request sort-type :sort-type}
+   org board-by-uuid allowed-boards user-id]
   (let [order (if (= direction :before) :desc :asc)
         limit (if digest-request 0 config/default-activity-limit)
         entries (entry-res/paginated-entries-by-org conn (:uuid org) order start direction limit sort-type allowed-boards
@@ -38,7 +38,7 @@
 
 (defn- assemble-follow-ups
   "Assemble the requested (by the params) follow-up entries for the provided user."
-  [conn {start :start direction :direction must-see :must-see} org sort-type board-by-uuid
+  [conn {start :start direction :direction must-see :must-see sort-type :sort-type} org board-by-uuid
    allowed-boards user-id]
   (let [order (if (= direction :before) :desc :asc)
         entries (entry-res/list-all-entries-by-follow-ups conn (:uuid org) user-id order start direction
@@ -100,7 +100,7 @@
                              sort-type (if (= sort "activity") :recent-activity :recently-posted)
                              start-params (update ctx-params :start #(or % (db-common/current-timestamp))) ; default is now
                              direction (or (#{:after} (keyword (:direction ctx-params))) :before) ; default is before
-                             params (merge start-params {:direction direction})
+                             params (merge start-params {:direction direction :sort-type sort-type})
                              boards (board-res/list-boards-by-org conn org-id [:created-at :updated-at :authors :viewers :access])
                              allowed-boards (map :uuid (filter #(access/access-level-for org % user) boards))
                              board-uuids (map :uuid boards)
@@ -109,8 +109,8 @@
                              fixed-params (if (= (:auth-source user) "digest")
                                             (assoc params :digest-request true)
                                             params)
-                             activity (assemble-activity conn fixed-params org sort-type board-by-uuid allowed-boards user-id)]
-                          (activity-rep/render-activity-list params org "entries" sort-type activity boards user))))
+                             activity (assemble-activity conn fixed-params org board-by-uuid allowed-boards user-id)]
+                          (activity-rep/render-activity-list params org "entries" activity boards user))))
 
 ;; A resource for operations on the activity of a particular Org
 (defresource follow-ups [conn slug]
@@ -130,15 +130,16 @@
   ;; Check the request
   :malformed? (fn [ctx] (let [ctx-params (keywordize-keys (-> ctx :request :params))
                               start (:start ctx-params)
-
                               valid-start? (if start (ts/valid-timestamp? start) true)
                               direction (keyword (:direction ctx-params))
                               ;; no direction is OK, but if specified it's from the allowed enumeration of options
                               valid-direction? (if direction (#{:before :after} direction) true)
+                              valid-sort? (or (not (contains? ctx-params :sort))
+                                              (= (:sort ctx-params) "activity"))
                               ;; a specified start/direction must be together or ommitted
                               pairing-allowed? (or (and start direction)
                                                     (and (not start) (not direction)))]
-                           (not (and valid-start? valid-direction? pairing-allowed?))))
+                           (not (and valid-start? valid-sort? valid-direction? pairing-allowed?))))
 
   ;; Existentialism
   :exists? (fn [ctx] (if-let* [_slug? (slugify/valid-slug? slug)
@@ -156,14 +157,14 @@
                              sort-type (if (= sort "activity") :recent-activity :recently-posted)
                              start-params (update ctx-params :start #(or % (db-common/current-timestamp))) ; default is now
                              direction (or (#{:after} (keyword (:direction ctx-params))) :before) ; default is before
-                             params (merge start-params {:direction direction})
+                             params (merge start-params {:direction direction :sort-type sort-type})
                              boards (board-res/list-boards-by-org conn org-id [:created-at :updated-at :authors :viewers :access])
                              allowed-boards (map :uuid (filter #(access/access-level-for org % user) boards))
                              board-uuids (map :uuid boards)
                              board-slugs-and-names (map #(array-map :slug (:slug %) :access (:access %) :name (:name %)) boards)
                              board-by-uuid (zipmap board-uuids board-slugs-and-names)
-                             activity (assemble-follow-ups conn params org sort-type board-by-uuid allowed-boards user-id)]
-                          (activity-rep/render-activity-list params org "follow-ups" sort-type activity boards user))))
+                             activity (assemble-follow-ups conn params org board-by-uuid allowed-boards user-id)]
+                          (activity-rep/render-activity-list params org "follow-ups" activity boards user))))
 
 ;; ----- Routes -----
 

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -18,12 +18,10 @@
             [oc.storage.async.notification :as notification]
             [oc.storage.representations.media-types :as mt]
             [oc.storage.representations.board :as board-rep]
-            [oc.storage.representations.entry :as entry-rep]
             [oc.storage.resources.common :as common-res]
             [oc.storage.resources.org :as org-res]
             [oc.storage.resources.board :as board-res]
             [oc.storage.resources.entry :as entry-res]
-            [oc.storage.resources.reaction :as reaction-res]
             [oc.storage.lib.timestamp :as ts]
             [oc.storage.urls.board :as board-url]))
 

--- a/src/oc/storage/api/boards.clj
+++ b/src/oc/storage/api/boards.clj
@@ -29,6 +29,11 @@
 
 ;; ----- Utility functions -----
 
+(defn- default-board-params []
+  {:sort-type :recent-activity
+   :start (db-common/current-timestamp)
+   :direction :before})
+
 (defun- assemble-board
   "Assemble the entry, author, and viewer data needed for a board response."
 
@@ -40,44 +45,21 @@
         entries (if (:draft board)
                   (filterv #(= (:board-uuid %) (:uuid board)) all-drafts)
                   all-drafts)
-        board-uuids (distinct (map :board-uuid entries))
-        boards (filter map? (map #(board-res/get-board conn %) board-uuids))
-        board-map (zipmap (map :uuid boards) boards)
-        entry-reps (map #(entry-rep/render-entry-for-collection org (or (board-map (:board-uuid %)) board) %
-                            [] []
-                            (:access-level ctx) (-> ctx :user :user-id))
-                        entries)]
-    (assoc board :entries entry-reps)))
+        sorted-entries (reverse (sort-by :updated-at entries))]
+    (merge board {:entries sorted-entries})))
 
-  ;; Regular board. used on board creation since it doesn't need pagination yet
-  ([conn org :guard map? board :guard map? ctx]
-  (let [org-slug (:slug org)
-        slug (:slug board)
-        entries (entry-res/paginated-entries-by-board conn (:uuid board) :desc (db-common/current-timestamp) :before
-                 config/default-activity-limit :recent-activity {})
-        entry-reps (map #(entry-rep/render-entry-for-collection org board %
-                            (entry-rep/comments %)
-                            (reaction-res/aggregate-reactions (entry-rep/reactions %))
-                            (:access-level ctx) (-> ctx :user :user-id))
-                      entries)]
-    (assoc board :entries entry-reps)))
-
-  ;; Regular paginated board, used in all the other cases
-  ([conn sort-type params org :guard map? board :guard map? ctx]
-  (let [{start :start direction :direction must-see :must-see} params
+  ;; Regular paginated board
+  ([conn org :guard map? board :guard map? params :guard map? ctx]
+  (let [{start :start direction :direction must-see :must-see sort-type :sort-type} params
         access-level (:access-level ctx)
         user-id (-> ctx :user :user-id)
         order (if (= direction :before) :desc :asc)
         entries (entry-res/paginated-entries-by-board conn (:uuid board) order start direction
-                 config/default-activity-limit sort-type {:must-see must-see})
-        activities {:next-count (count entries)
-                    :direction direction}]
+                 config/default-activity-limit sort-type {:must-see must-see})]
     ;; Give each activity its board name
-    (merge board activities {:entries (map (fn [activity]
-                                            (merge activity {
-                                             :board-slug (:slug board)
-                                             :board-name (:name board)}))
-                                       entries)}))))
+    (merge board {:next-count (count entries)
+                  :direction direction
+                  :entries entries}))))
 
 ;; ----- Validations -----
 
@@ -217,7 +199,7 @@
                               ;; retrieve the board again to get final list of members
                               (board-res/get-board conn (:uuid board-result)))]
           (notification/send-trigger! (notification/->trigger :add org {:new created-board :notifications notifications} user invitation-note))
-          {:created-board (api-common/rep (assemble-board conn org created-board ctx))}))
+          {:created-board (api-common/rep (assemble-board conn org created-board (default-board-params) ctx))}))
     
     (do (timbre/error "Failed creating board for org:" org-slug) false))))
 
@@ -300,15 +282,16 @@
     :options false
     :get (fn [ctx] (let [ctx-params (keywordize-keys (-> ctx :request :params))
                          start (:start ctx-params)
-
                          valid-start? (if start (ts/valid-timestamp? start) true)
+                         valid-sort? (or (not (contains? ctx-params :sort))
+                                         (= (:sort ctx-params) "activity"))
                          direction (keyword (:direction ctx-params))
                          ;; no direction is OK, but if specified it's from the allowed enumeration of options
                          valid-direction? (if direction (#{:before :after} direction) true)
                          ;; a specified start/direction must be together or ommitted
                          pairing-allowed? (or (and start direction)
                                               (and (not start) (not direction)))]
-                     (not (and valid-start? valid-direction? pairing-allowed?))))
+                     (not (and valid-start? valid-sort? valid-direction? pairing-allowed?))))
     :patch (fn [ctx] (api-common/malformed-json? ctx))
     :delete false})
 
@@ -331,8 +314,11 @@
                                             ;; Draft board for the user
                                             (board-res/drafts-board org-uuid (:user ctx))
                                             ;; Regular board by slug
-                                            (board-res/get-board conn org-uuid slug)))]
-                        {:existing-org (api-common/rep org) :existing-board (api-common/rep board)}
+                                            (board-res/get-board conn org-uuid slug)))
+                               boards (board-res/list-boards-by-org conn org-uuid)
+                               boards-map (zipmap (map :uuid boards) boards)]
+                        {:existing-org (api-common/rep org) :existing-board (api-common/rep board)
+                         :existing-org-boards (api-common/rep boards-map)}
                         false))
 
   ;; Actions
@@ -344,20 +330,17 @@
                              board (or (:updated-board ctx) (:existing-board ctx))
                              ctx-params (keywordize-keys (-> ctx :request :params))
                              sort (:sort ctx-params)
-                             sort-type (if (= sort "activity") :recent-activity :recently-posted)]
-                          ;; For drafts board still use the full board
-                          (if (= (:slug board) (:slug board-res/default-drafts-board))
-                            (let [full-board (assemble-board conn org board ctx)
-                                  with-sorted-entries (update-in full-board [:entries] #(reverse (sort-by :updated-at %)))]
-                              (board-rep/render-board org sort-type with-sorted-entries ctx nil))
-                            ;; Render paginated board for all the rest
-                            (let [ctx-params (keywordize-keys (-> ctx :request :params))
-                                 start? (if (:start ctx-params) true false) ; flag if a start was specified
-                                 start-params (update ctx-params :start #(or % (db-common/current-timestamp))) ; default is now
-                                 direction (or (#{:after} (keyword (:direction ctx-params))) :before) ; default is before
-                                 params (merge start-params {:direction direction})
-                                 full-board (assemble-board conn sort-type params org board ctx)]
-                              (board-rep/render-board org sort-type full-board ctx params)))))
+                             sort-type (if (= sort "activity") :recent-activity :recently-posted)
+                             start-params (update ctx-params :start #(or % (db-common/current-timestamp))) ; default is now
+                             direction (or (#{:after} (keyword (:direction ctx-params))) :before) ; default is before
+                             drafts-board? (= (:slug board) (:slug board-res/default-drafts-board))
+                             ;; For drafts board don't use parameters
+                             params (when-not drafts-board?
+                                      (merge start-params {:direction direction :sort-type sort-type}))
+                             full-board (if drafts-board?
+                                          (assemble-board conn org board ctx)
+                                          (assemble-board conn org board params ctx))]
+                           (board-rep/render-board org full-board ctx params)))
   :handle-unprocessable-entity (fn [ctx]
     (api-common/unprocessable-entity-response (schema/check common-res/Board (:board-update ctx)))))
 
@@ -403,13 +386,14 @@
 
   ;; Responses
   :handle-created (fn [ctx] (let [pre-flight? (-> ctx :data :pre-flight)
+                                  org (:existing-org ctx)
                                   new-board (:created-board ctx)
                                   board-slug (:slug new-board)]
                               (if pre-flight?
                                 (api-common/blank-response)
                                 (api-common/location-response
                                   (board-url/url org-slug board-slug)
-                                  (board-rep/render-board (:existing-org ctx) nil new-board ctx nil)
+                                  (board-rep/render-board org new-board ctx (default-board-params))
                                   mt/board-media-type))))
   :handle-unprocessable-entity (fn [ctx]
     (api-common/unprocessable-entity-response (:reason ctx))))

--- a/src/oc/storage/representations/activity.clj
+++ b/src/oc/storage/representations/activity.clj
@@ -19,7 +19,7 @@
 
 (defn- pagination-link
   "Add `next` and/or `prior` links for pagination as needed."
-  [org collection-type sort-type {:keys [start direction]} data]
+  [org collection-type {:keys [start direction sort-type]} data]
   (let [activity (:activity data)
         activity? (not-empty activity)
         last-activity (last activity)
@@ -42,8 +42,9 @@
   Given an org and a sequence of entry maps, create a JSON representation of a list of
   activity for the API.
   "
-  [params org collection-type sort-type activity boards user]
-  (let [collection-url (url collection-type org sort-type)
+  [params org collection-type activity boards user]
+  (let [sort-type (:sort-type params)
+        collection-url (url collection-type org sort-type)
         recent-activity-sort? (= sort-type :recent-activity)
         other-sort-url (url collection-type org (if recent-activity-sort? :recently-posted :recent-activity))
         collection-rel (if recent-activity-sort? "activity" "self")
@@ -51,7 +52,7 @@
         links [(hateoas/link-map collection-rel hateoas/GET collection-url {:accept mt/activity-collection-media-type} {})
                (hateoas/link-map other-sort-rel hateoas/GET other-sort-url {:accept mt/activity-collection-media-type} {})
                (hateoas/up-link (org-rep/url org) {:accept mt/org-media-type})
-               (pagination-link org collection-type sort-type params activity)]]
+               (pagination-link org collection-type params activity)]]
     (json/generate-string
       {:collection {:version hateoas/json-collection-version
                     :href collection-url

--- a/src/oc/storage/representations/board.clj
+++ b/src/oc/storage/representations/board.clj
@@ -49,7 +49,7 @@
 
 (defn- pagination-link
   "Add `next` links for pagination as needed."
-  [org board sort-type {:keys [start direction]} data]
+  [org board {:keys [start direction sort-type]} data]
   (let [activity (:entries data)
         activity? (not-empty activity)
         last-activity (last activity)
@@ -76,10 +76,10 @@
     (assoc board :links full-links)))
 
 (defn- board-links
-  [board org-slug sort-type access-level params]
+  [board org-slug access-level params]
   (let [slug (:slug board)
         is-drafts-board? (= slug "drafts")
-        page-link (when-not is-drafts-board? (pagination-link org-slug slug sort-type params board))
+        page-link (when-not is-drafts-board? (pagination-link org-slug slug params board))
         ;; Everyone gets these
         links (remove nil? [page-link
                             (self-link org-slug slug :recently-posted)
@@ -126,15 +126,13 @@
 
 (defn render-board
   "Create a JSON representation of the board for the REST API"
-  [org sort-type board ctx params]
+  [org board ctx params]
   (let [access-level (:access-level ctx)
         rep-props (if (or (= :author access-level) (= :viewer access-level))
                       representation-props
                       public-representation-props)
-        rendered-entries (if (= (:slug board) (:slug board-res/default-drafts-board))
-                           (:entries board)
-                           (map #(render-entry-for-collection org board % access-level (-> ctx :user :user-id))
-                            (:entries board)))
+        boards-map (:existing-org-boards ctx)
+        is-drafts-board? (= (:slug board) (:slug board-res/default-drafts-board))
         authors (:authors board)
         author-reps (map #(render-author-for-collection (:slug org) (:slug board) % access-level) authors)
         viewers (:viewers board)
@@ -143,7 +141,9 @@
       (-> board
         (assoc :authors author-reps)
         (assoc :viewers viewer-reps)
-        (board-links (:slug org) sort-type access-level params)
-        (assoc :entries rendered-entries)
+        (board-links (:slug org) access-level params)
+        (assoc :entries (map #(let [entry-board (if is-drafts-board? (boards-map (:board-uuid %)) board)]
+                                (render-entry-for-collection org entry-board % access-level (-> ctx :user :user-id)))
+                         (:entries board)))
         (select-keys rep-props))
       {:pretty config/pretty?})))

--- a/src/oc/storage/representations/board.clj
+++ b/src/oc/storage/representations/board.clj
@@ -134,9 +134,15 @@
         rendered-entries (if (= (:slug board) (:slug board-res/default-drafts-board))
                            (:entries board)
                            (map #(render-entry-for-collection org board % access-level (-> ctx :user :user-id))
-                            (:entries board)))]
+                            (:entries board)))
+        authors (:authors board)
+        author-reps (map #(render-author-for-collection (:slug org) (:slug board) % access-level) authors)
+        viewers (:viewers board)
+        viewer-reps (map #(render-viewer-for-collection (:slug org) (:slug board) % access-level) viewers)]
     (json/generate-string
       (-> board
+        (assoc :authors author-reps)
+        (assoc :viewers viewer-reps)
         (board-links (:slug org) sort-type access-level params)
         (assoc :entries rendered-entries)
         (select-keys rep-props))


### PR DESCRIPTION
Bug: board creation is currently broken.

Since single query PR went on we have had problems in the board endpoint. The problem was that the render was happening half in the api endpoint (the entries) and half in the representation namespace. Also drafts board was treated differently. I tried to remove this diversification and make sure all the rendering happens in the representation.

To test:
- test AP
- test AP pagination
- test FU
- test FU pagination
- add a new board
- edit the board settings (name, access, private users, private user roles)
- delete the board
- add a private board
- add other authors and viewers after creations
- check the authors and viewers are returned with the proper data (user-id and remove link)
- add a draft to the board
- publish a post to the board
- add a public board
- publish > 10 posts in the public board
- test pagination on the public board
