### PR TITLE
Viewers reminders link

### DIFF
--- a/src/oc/storage/representations/org.clj
+++ b/src/oc/storage/representations/org.clj
@@ -77,8 +77,14 @@
         nil))
     org))
 
+(defn- viewer-is-private-board-author? [org user]
+  (some #((:authors %) (-> user :user-id)) (:boards org)))
+
 (defn- reminders-link [org access-level user]
-  (if (and (not (:id-token user)) (or (= access-level :author) (= access-level :viewer)))
+  (if (and (not (:id-token user))
+           (or (= access-level :author)
+               (and (= access-level :viewer)
+                    (viewer-is-private-board-author? org user))))
     (update-in org [:links] conj
       (hateoas/link-map
         "reminders"

--- a/src/oc/storage/representations/org.clj
+++ b/src/oc/storage/representations/org.clj
@@ -78,7 +78,7 @@
     org))
 
 (defn- viewer-is-private-board-author? [org user]
-  (some #((:authors %) (-> user :user-id)) (:boards org)))
+  (some #((set (:authors %)) (:user-id user)) (:boards org)))
 
 (defn- reminders-link [org access-level user]
   (if (and (not (:id-token user))


### PR DESCRIPTION
Avoid sending reminders link to viewers, make sure they don't have private boards with edit permissions.

To test:
- invite a viewer
- accept invite
- do you not see the link with "reminders" rel in the org response?
- do you not see the Recurring updates item in the menu?
- now with the initial user add a private board
- add the viewer to the private board as viewer only
- refresh the viewer page
- do you not see the link with "reminders" rel in the org response?
- do you not see the Recurring updates item in the menu?
- now with the initial user change the viewer role in the private board to contributor
- refresh the viewer page
- do you see the link with "reminders" rel in the org response?
- do you see the Recurring updates item in the menu?
