### PR TITLE
Single query performance improvements

### DIFF
--- a/src/oc/storage/db/common.clj
+++ b/src/oc/storage/db/common.clj
@@ -105,7 +105,9 @@
             ;; Merge in a last-activity-at date for each post (last comment created-at, fallback to published-at)
             (r/merge query (r/fn [post-row]
               {:last-activity-at (-> (r/table relation-table-name)
-                                     (r/get-all [(r/get-field post-row :uuid) user-id nil] {:index :resource-uuid-author-uuid-reaction})
+                                     (r/get-all [(r/get-field post-row :uuid) nil] {:index :resource-uuid-reaction})
+                                     (r/filter (r/fn [interaction-row]
+                                       (r/ne (r/get-field interaction-row [:author :user-id]) user-id)))
                                      (r/max :created-at)
                                      (r/default
                                       (r/default

--- a/src/oc/storage/db/common.clj
+++ b/src/oc/storage/db/common.clj
@@ -119,7 +119,7 @@
                      (r/gt (r/get-field post-row :last-activity-at) minimum-date-timestamp)
                      ;; All records that have a dismiss-at later or equal than the last activity
                      (r/gt (r/get-field post-row :last-activity-at)
-                           (r/default (r/get-field (r/get-field (r/get-field post-row :user-visibility) user-id) :dismiss-at) "")))))
+                           (r/default (r/get-field post-row [:user-visibility user-id :dismiss-at]) "")))))
             ;; Merge in all the interactions
             (if-not count
               (r/merge query (r/fn [post-row]

--- a/src/oc/storage/db/common.clj
+++ b/src/oc/storage/db/common.clj
@@ -29,9 +29,9 @@
             (r/get-all query index-values {:index index-name})
             ;; Filter on the allowed-boards
             (if (sequential? allowed-boards)
-              (r/fn [post-row]
+              (r/filter query (r/fn [post-row]
                 ;; All records in boards the user has no access
-                (r/contains allowed-boards (r/get-field post-row :board-uuid)))
+                (r/contains allowed-boards (r/get-field post-row :board-uuid))))
               query)
             ;; Merge in a last-activity-at date for each post, which is the
             ;; last comment created-at, with fallback to published-at or created-at for published entries

--- a/src/oc/storage/db/migrations/1580143129669_add_comment_index.edn
+++ b/src/oc/storage/db/migrations/1580143129669_add_comment_index.edn
@@ -1,0 +1,19 @@
+(ns oc.storage.db.migrations.add-comment-index
+  (:require [rethinkdb.query :as r]
+            [oc.lib.db.migrations :as m]
+            [oc.storage.resources.common :as common]))
+
+(defn up [conn]
+  (println "Create resource-uuid-reaction index...")
+  (println (m/create-compound-index conn common/interaction-table-name :resource-uuid-reaction
+              (r/fn [row]
+                [(r/get-field row :resource-uuid)
+                 (r/get-field row :reaction)])))
+
+  (println "Create resource-uuid-author-uuid-reaction index...")
+  (println (m/create-compound-index conn common/interaction-table-name :resource-uuid-author-uuid-reaction
+              (r/fn [row]
+                [(r/get-field row :resource-uuid)
+                 (r/get-field row [:author :user-id])
+                 (r/get-field row :reaction)])))
+  true) ; return true on success

--- a/src/oc/storage/db/migrations/1580143129669_add_comment_index.edn
+++ b/src/oc/storage/db/migrations/1580143129669_add_comment_index.edn
@@ -4,11 +4,11 @@
             [oc.storage.resources.common :as common]))
 
 (defn up [conn]
-  (println "Create resource-uuid-reaction index...")
-  (println (m/create-compound-index conn common/interaction-table-name :resource-uuid-reaction
+  (println "Create resource-uuid-comment index...")
+  (println (m/create-compound-index conn common/interaction-table-name :resource-uuid-comment
             (r/fn [row]
               [(r/get-field row :resource-uuid)
-               (r/get-field row :reaction)])))
+               (-> (r/get-filed row :body) seq boolean)])))
   (println "Create created-at index...")
   (println (m/create-compound-index conn common/interaction-table-name :created-at
             (r/fn [row]

--- a/src/oc/storage/db/migrations/1580143129669_add_comment_index.edn
+++ b/src/oc/storage/db/migrations/1580143129669_add_comment_index.edn
@@ -6,14 +6,11 @@
 (defn up [conn]
   (println "Create resource-uuid-reaction index...")
   (println (m/create-compound-index conn common/interaction-table-name :resource-uuid-reaction
-              (r/fn [row]
-                [(r/get-field row :resource-uuid)
-                 (r/get-field row :reaction)])))
-
-  (println "Create resource-uuid-author-uuid-reaction index...")
-  (println (m/create-compound-index conn common/interaction-table-name :resource-uuid-author-uuid-reaction
-              (r/fn [row]
-                [(r/get-field row :resource-uuid)
-                 (r/get-field row [:author :user-id])
-                 (r/get-field row :reaction)])))
+            (r/fn [row]
+              [(r/get-field row :resource-uuid)
+               (r/get-field row :reaction)])))
+  (println "Create created-at index...")
+  (println (m/create-compound-index conn common/interaction-table-name :created-at
+            (r/fn [row]
+              (r/get-field row :created-at))))
   true) ; return true on success

--- a/src/oc/storage/db/migrations/1580143129669_add_comment_index.edn
+++ b/src/oc/storage/db/migrations/1580143129669_add_comment_index.edn
@@ -8,7 +8,7 @@
   (println (m/create-compound-index conn common/interaction-table-name :resource-uuid-comment
             (r/fn [row]
               [(r/get-field row :resource-uuid)
-               (-> (r/get-filed row :body) seq boolean)])))
+               (-> (r/get-field row :body) seq boolean)])))
   (println "Create created-at index...")
   (println (m/create-compound-index conn common/interaction-table-name :created-at
             (r/fn [row]


### PR DESCRIPTION
Add 2 indexes to the interactions table:
- resource-uuid-comment: used to filter on only comments of a certain post, used from the section pagination query and the inbox query
- created-at: used to get the bigger created-at when trying to calculate the last-activity-at value

Also changes how the filter/sort are applied in the queries (AP, section and inbox):
- apply filter on allowed boards before calculating the last-activity-at (for inbox query filter also on user unfollows)
- use max instead of sort/nth 0 to get the last comment created-at
- use the new resource-uuid-comment index to get all the comments

Is this the right place to add migration for the `interactions` table?
I added it here because it's used only here, but all migrations for this table are in open-company-interactions

To test:
- before running this branch/migrations add the following posts to your account
- with user U1
- publish post P1 in section S1
- publish post P2 in section S2
- with user U2
- publish post P3 in section S1
- with user U1 add a comment to post P3
- with user U2 add a comment to post P2
- take a screenshot of AP and Unread of user U1 and U2
- run this branch
- check that AP and Unread still look the same for user U1 and U2

NB: in general you need to make sure that comments from you or other users count when sorting the posts in AP or Bookmarks or in sections. Only comments from other users make a post come back into your Unread and the last added comment is used to sort.