### PR TITLE
Fix resource-uuid-comment index

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -121,7 +121,7 @@
         ;; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-checkall "0.1.1"]
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
-        [lein-pprint "1.2.0"]
+        [lein-pprint "1.3.2"]
         ;; Check for outdated dependencies https://github.com/xsc/lein-ancient
         [lein-ancient "0.6.15"]
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell

--- a/src/oc/storage/db/migrations/1581013849396_fix_resource_uuid_comment_index.edn
+++ b/src/oc/storage/db/migrations/1581013849396_fix_resource_uuid_comment_index.edn
@@ -4,7 +4,6 @@
             [oc.storage.resources.common :as common]))
 
 (defn up [conn]
-  ;; Do great things
   (println (m/remove-index conn common/interaction-table-name "resource-uuid-comment"))
   (println (m/create-compound-index conn common/interaction-table-name :resource-uuid-comment
             (r/fn [row]

--- a/src/oc/storage/db/migrations/1581013849396_fix_resource_uuid_comment_index.edn
+++ b/src/oc/storage/db/migrations/1581013849396_fix_resource_uuid_comment_index.edn
@@ -1,0 +1,15 @@
+(ns oc.storage.db.migrations.fix-resource-uuid-comment-index
+  (:require [rethinkdb.query :as r]
+            [oc.lib.db.migrations :as m]
+            [oc.storage.resources.common :as common]))
+
+(defn up [conn]
+  ;; Do great things
+  (println (m/remove-index conn common/interaction-table-name "resource-uuid-comment"))
+  (println (m/create-compound-index conn common/interaction-table-name :resource-uuid-comment
+            (r/fn [row]
+              [(r/get-field row :resource-uuid)
+               (-> (r/get-field row :body)
+                   (r/default false)
+                   (r/coerce-to :bool))])))
+  true) ; return true on success


### PR DESCRIPTION
Bug: right now resource-uuid-comment return reactions as comments too.

This removes the index and recreate it with the right expression to calculate the boolean value for comments/reactions.

To test:
- add a post with user A
- add a comment with user B
- user A opens the post
- user B react to the post
- before this user A would have seen the post in Unread
- after he shouldn't