### PR TITLE
Follow-ups cleanup

### DIFF
--- a/src/oc/storage/db/migrations/1582043152198_bookmarks_cleanup.edn
+++ b/src/oc/storage/db/migrations/1582043152198_bookmarks_cleanup.edn
@@ -1,0 +1,20 @@
+(ns oc.storage.db.migrations.bookmarks-cleanup
+  (:require [rethinkdb.query :as r]
+            [oc.lib.db.migrations :as m]
+            [oc.storage.config :as config]
+            [oc.lib.db.common :as db-common]
+            [oc.storage.resources.entry :as entry]
+            [oc.storage.resources.board :as board]))
+
+(defn- delete-follow-ups [conn]
+  (println "Remove all :follow-ups values from the existing entries.")
+  (-> (r/table entry/table-name)
+    (r/replace (r/fn [e]
+      (r/without e [:follow-ups])))
+    (r/run conn)))
+
+(defn up [conn]
+  (delete-follow-ups conn)
+  (println "Removing follow-ups multi index:")
+  (println (m/remove-index conn entry/table-name "org-uuid-status-follow-ups-completed?-assignee-user-id-map-multi"))
+  true) ; return true on success

--- a/src/oc/storage/db/migrations/1582043152198_bookmarks_cleanup.edn
+++ b/src/oc/storage/db/migrations/1582043152198_bookmarks_cleanup.edn
@@ -8,10 +8,10 @@
 
 (defn- delete-follow-ups [conn]
   (println "Remove all :follow-ups values from the existing entries.")
-  (-> (r/table entry/table-name)
-    (r/replace (r/fn [e]
-      (r/without e [:follow-ups])))
-    (r/run conn)))
+  (println (-> (r/table entry/table-name)
+            (r/replace (r/fn [e]
+              (r/without e [:follow-ups])))
+            (r/run conn))))
 
 (defn up [conn]
   (delete-follow-ups conn)

--- a/src/oc/storage/representations/entry.clj
+++ b/src/oc/storage/representations/entry.clj
@@ -24,7 +24,7 @@
                            :board-uuid :board-slug :board-name :board-access
                            :team-id :author :publisher :published-at
                            :video-id :video-processed :video-image :video-duration
-                           :created-at :updated-at :revision-id :follow-ups
+                           :created-at :updated-at :revision-id
                            :new-at :new-comments-count :bookmarked-at])
 
 ;; ----- Utility functions -----

--- a/src/oc/storage/resources/board.clj
+++ b/src/oc/storage/resources/board.clj
@@ -68,7 +68,7 @@
 
 ;; ----- Board Slug -----
 
-(def reserved-slugs #{"create-board" "settings" "boards" "all-posts" "drafts" "must-see" "follow-ups" "bookmarks" "inbox" "new"})
+(def reserved-slugs #{"create-board" "settings" "boards" "all-posts" "drafts" "must-see" "bookmarks" "inbox" "new"})
 
 (declare list-boards-by-org)
 (defn taken-slugs

--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -156,8 +156,7 @@
   :created-at lib-schema/ISO8601
   :updated-at lib-schema/ISO8601
 
-  (schema/optional-key :follow-ups) [FollowUp]
-  (schema/optional-key :bookmarks) [(schema/if string? lib-schema/UniqueID Bookmark)]
+  (schema/optional-key :bookmarks) [Bookmark]
   (schema/optional-key :user-visibility) (schema/maybe {schema/Keyword UserVisibility})
 })
 

--- a/src/oc/storage/resources/entry.clj
+++ b/src/oc/storage/resources/entry.clj
@@ -446,23 +446,6 @@
   {:pre [(db-common/conn? conn)]}
   (db-common/read-resources conn table-name :board-uuid [board-uuid] ["uuid" "status"]))
 
-(schema/defn ^:always-validate list-all-entries-by-follow-ups
-  "Given the UUID of the user, return all the published entries with follow-ups for the user."
-  ([conn org-uuid :- lib-schema/UniqueID user-id :- lib-schema/UniqueID order start :- lib-schema/ISO8601 direction limit sort-type
-    allowed-boards :- [lib-schema/UniqueID]]
-    (list-all-entries-by-follow-ups conn org-uuid user-id order start direction limit sort-type allowed-boards {:count false}))
-
-  ([conn org-uuid :- lib-schema/UniqueID user-id :- lib-schema/UniqueID order start :- lib-schema/ISO8601 direction limit sort-type
-    allowed-boards :- [lib-schema/UniqueID] {:keys [count] :or {count false}}]
-  {:pre [(db-common/conn? conn)
-         (#{:desc :asc} order)
-         (#{:before :after} direction)
-         (integer? limit)
-         (#{:recent-activity :recently-posted} sort-type)]}
-  (storage-db-common/read-paginated-entries conn table-name :org-uuid-status-follow-ups-completed?-assignee-user-id-map-multi
-   [[org-uuid :published false user-id]] order start direction limit sort-type common/interaction-table-name allowed-boards 
-   list-comment-properties {:count count})))
-
 (schema/defn ^:always-validate list-all-entries-for-inbox
   "Given the UUID of the user, return all the entries the user has access to that have been published
    or have had activity in the last config/unread-days-limit days, then filter by user-visibility on the remaining."


### PR DESCRIPTION
This PR is intended to:
- delete all `:follow-ups` data from entries
- remove follow-ups representation keys
- remove follow-ups render keys
- remove follow-ups retrieve functions

To test:
- before switching to this branch identify at least a post with `:follow-ups` data in it
- switch to this branch and start storage
- check that entry has no `:follow-ups` key anymore
- try opening that entry on web client
- no errors on web or storage?