### PR TITLE
Allow storing `utm-data` map in the org if it's provided at org creation

### DIFF
--- a/src/oc/storage/resources/common.clj
+++ b/src/oc/storage/resources/common.clj
@@ -75,6 +75,7 @@
   :promoted schema/Bool
   (schema/optional-key :content-visibility) ContentVisibility
   (schema/optional-key :why-carrot) (schema/maybe schema/Str)
+  (schema/optional-key :utm-data) schema/Any
   :authors [lib-schema/UniqueID]
   :author lib-schema/Author
   :created-at lib-schema/ISO8601

--- a/src/oc/storage/resources/org.clj
+++ b/src/oc/storage/resources/org.clj
@@ -20,7 +20,7 @@
 
 (def ignored-properties
   "Properties of a resource that are ignored during an update."
-  (clojure.set/union reserved-properties #{:team-id}))
+  (clojure.set/union reserved-properties #{:team-id :utm-data}))
 
 ;; ----- Data Defaults -----
 


### PR DESCRIPTION
Supports https://github.com/open-company/open-company-web/pull/1158