### PR TITLE
Fix entry revisions

### DIFF
--- a/src/oc/storage/api/entries.clj
+++ b/src/oc/storage/api/entries.clj
@@ -262,7 +262,7 @@
       (timbre/info "Created entry for:" entry-for "as" (:uuid entry-result))
       (when (= (keyword (:status entry-result)) :published)
         (undraft-board conn user org board)
-        (entry-res/delete-versions conn entry-result)
+        ; (entry-res/delete-versions conn entry-result)
         (auto-share-on-publish conn ctx entry-result))
       (notification/send-trigger! (notification/->trigger :add org board {:new entry-result} user nil))
       {:created-entry (api-common/rep entry-result)})
@@ -343,7 +343,7 @@
       (when old-board
         (let [remaining-entries (entry-res/list-all-entries-by-board conn (:uuid old-board))]
           (board-res/maybe-delete-draft-board conn org old-board remaining-entries user)))
-      (entry-res/delete-versions conn final-entry)
+      ; (entry-res/delete-versions conn final-entry)
       (auto-share-on-publish conn ctx final-entry)
       (timbre/info "Published entry:" entry-for)
       (notification/send-trigger! (notification/->trigger :add org board {:new final-entry} user nil))
@@ -361,8 +361,8 @@
       (when (= (keyword (:status entry)) :draft)
         (let [remaining-entries (entry-res/list-all-entries-by-board conn (:uuid board))]
           (board-res/maybe-delete-draft-board conn org board remaining-entries (:user ctx))))
-      (when (not= (keyword (:status entry)) :published)
-        (entry-res/delete-versions conn (assoc entry :delete-entry true)))
+      ; (when (not= (keyword (:status entry)) :published)
+      ;   (entry-res/delete-versions conn (assoc entry :delete-entry true)))
       (timbre/info "Deleted entry for:" entry-for)
       (notification/send-trigger! (notification/->trigger :delete org board {:old entry} (:user ctx) nil))
       true)

--- a/src/oc/storage/db/common.clj
+++ b/src/oc/storage/db/common.clj
@@ -222,9 +222,7 @@
                      {:revision-id rev-id
                       :version-uuid versioned-uuid
                       :revision-date ts
-                      :revision-author author
-                      :created-at ts
-                      :updated-at ts})))
+                      :revision-author author})))
                  (r/run conn)))]
     (if (and @version
              (= 1 (:inserted insert)))

--- a/src/oc/storage/db/common.clj
+++ b/src/oc/storage/db/common.clj
@@ -217,16 +217,14 @@
                                  (r/add q 1)
                                  (r/run q conn))
                          versioned-uuid (str (:uuid updated-entry) "-v" rev-id)
-                         ts (db-common/current-timestamp)
-                         latest-author (assoc author :updated-at ts)]
+                         ts (db-common/current-timestamp)]
                      (reset! version versioned-uuid)
                      {:revision-id rev-id
                       :version-uuid versioned-uuid
                       :revision-date ts
-                      :revision-author latest-author
+                      :revision-author author
                       :created-at ts
-                      :updated-at ts
-                      :author (conj (:author updated-entry) latest-author)})))
+                      :updated-at ts})))
                  (r/run conn)))]
     (if (and @version
              (= 1 (:inserted insert)))

--- a/src/oc/storage/db/migrations/1597845509817_versions_entry_uuid_index.edn
+++ b/src/oc/storage/db/migrations/1597845509817_versions_entry_uuid_index.edn
@@ -1,0 +1,11 @@
+(ns oc.storage.db.migrations.versions-entry-uuid-index
+  (:require [rethinkdb.query :as r]
+            [oc.lib.db.migrations :as m]
+            [oc.storage.config :as config]
+            [oc.storage.resources.entry :as entry]))
+
+(defn up [conn]
+  ;; Do great things
+  (println (m/create-index conn entry/versions-table-name "uuid"))
+
+  true) ; return true on success


### PR DESCRIPTION
We have a revisions table that keeps track of every version we save of an entry.
That's not very useful since it deletes all the old versions when a post gets published, in the case i was investigating now we most probably had a race condition during publishing (because the client can do 2 different calls when while publishing: if the autosave is running it can happen that 2 calls are called together).
Also, we have seen an intermittent error for a duplicated primary key on the versioning table.

Here are the improvements:
- never delete the versions (we can go in and delete manually those that are older than x or for posts that have been deleted if we have space issues)
- read the last version saved of entry while creating a new one in an (almost) atomic way to reduce the possible duplicated key errors

To review:
- on Storage and Web mainline
- comment out `oc.storage.api.entries:346`
- add this line `(Thread/sleep 6000)` at `oc.storage.resources.entry:116`
- open the client
- type something in QP
- wait for the first call to create the post
- now type some more
- when you see the PATCH request start click the publish button
- 💥  500 Duplicated primary key `version-uuid`
- now cleanup changes
- switch to this storage branch (keep web on mainline)
- add `(Thread/sleep 6000)` at `oc.storage.api.entries:274` (before saving the entry in the DB)
- switch to the client
- open QP
- type something to create a post
- type some more to start a PATCH request
- while the request is running click publish
- did it work? Good
- do you see the latest version published?
- do you see 2 versions in the versions table (1 for the first PATCH and 1 for the publish action)? (you can use the `uuid` index on the `versions_entries` table)